### PR TITLE
Calibration wrapping workaround

### DIFF
--- a/Tools/AnyMocap/InverseDynamicSettings.any
+++ b/Tools/AnyMocap/InverseDynamicSettings.any
@@ -50,3 +50,21 @@ Main.RunAnalysis.InverseDynamics =
  nStep= max({N_STEP-4, 1});  
  
 };
+
+
+// WORKAROUND for errors in wrapping after calibration. 
+ Main.HumanModel.Calibration = 
+ {
+   CalibrationSequence = {
+      AnyOperation& FixWrapping = .FixWrappingWorkAround.Kinematics;
+   };
+   AnyKinStudy FixWrappingWorkAround = 
+   {
+       AnyFolder& studyref = Main.Studies.InverseDynamicStudy;
+       Gravity = studyref.Gravity;
+       nStep = 1;
+       tStart = studyref.tStart;
+       Kinematics.PosAnalysisOnlyOnOff = On;
+       tEnd = studyref.tEnd;
+   };
+ };


### PR DESCRIPTION
In GitLab by @melund on Feb 5, 2019, 08:44

This is a workaround to avoid the problems with wrapping which sometimes appear after calibration.