### PR TITLE
WIP: Volume recruitment

### DIFF
--- a/Application/Examples/VolumeRecruitment/HookTLEMMuscles.any
+++ b/Application/Examples/VolumeRecruitment/HookTLEMMuscles.any
@@ -1,0 +1,444 @@
+
+
+
+    
+#if BM_FOOT_MODEL == _FOOT_MODEL_DEFAULT_
+
+SoleusMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SoleusMedialis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SoleusMedialis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SoleusLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SoleusLateralis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SoleusLateralis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#if BM_LEG_MORPHOLOGY == 1
+GastrocnemiusLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GastrocnemiusMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+GastrocnemiusLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GastrocnemiusMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+
+#if BM_LEG_MORPHOLOGY ==1
+FlexorDigitorumLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorDigitorumLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorDigitorumLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+FlexorDigitorumLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorDigitorumLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorDigitorumLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorDigitorumLongus4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 1
+FlexorHallucisLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorHallucisLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorHallucisLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+FlexorHallucisLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorHallucisLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+FlexorHallucisLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+TibialisPosteriorLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisPosteriorLateralis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisPosteriorLateralis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisPosteriorMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisPosteriorMedialis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisPosteriorMedialis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisAnterior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisAnterior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TibialisAnterior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusBrevis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusBrevis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusBrevis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#if BM_LEG_MORPHOLOGY == 1
+
+PeroneusTertius1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusTertius2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+PeroneusTertius3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+ExtensorDigitorumLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ExtensorDigitorumLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ExtensorDigitorumLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#if BM_LEG_MORPHOLOGY == 2
+ExtensorDigitorumLongus4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+ExtensorHallucisLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ExtensorHallucisLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ExtensorHallucisLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+#endif // BM_FOOT_MODEL != _FOOT_MODEL_DEFAULT_
+
+
+// Start Quadriceps
+// Note that all Vastus muscles have their insertion on the patella. The patella has 
+// been defined as a segment in the file seg.any. 
+// The Rectus Femoris has its origin on the Pelvis and its insertion on the patella.
+// Also the Pelvis has been defined in the seg.any file. 
+
+
+
+//VASTUS LATERALIS INFERIOR WRAPPING
+
+VastusLateralisInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisInferior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisInferior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisInferior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisInferior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//VASTUS LATERALIS SUPERIOR WRAPPING
+
+VastusLateralisSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusLateralisSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//VASTUS MEDIALIS INFERIOR WRAPPING
+
+VastusMedialisInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//VASTUS MEDIALIS MID WRAPPING
+
+VastusMedialisMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisMid2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//VASTUS MEDIALIS SUPERIOR WRAPPING
+
+VastusMedialisSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisSuperior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#if BM_LEG_MORPHOLOGY == 1
+VastusMedialisSuperior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusMedialisSuperior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+//VASTUS INTERMEDIUS WRAPPING
+
+VastusIntermedius1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusIntermedius2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusIntermedius3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusIntermedius4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusIntermedius5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+VastusIntermedius6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//RECTUS FEMORIS WRAPPING
+
+RectusFemoris1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+RectusFemoris2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+// End Quadriceps.
+
+// Start of Hamstrings
+#if BM_LEG_MORPHOLOGY == 2
+
+Semitendinosus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Semimembranosus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Semimembranosus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Semimembranosus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+BicepsFemorisCaputLongum1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+
+
+
+#else
+
+Semitendinosus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Semimembranosus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#if BM_LEG_MORPHOLOGY == 2
+Semimembranosus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Semimembranosus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+BicepsFemorisCaputLongum1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+BicepsFemorisCaputBreve3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#endif
+// End of Hamstrings
+
+
+// Start hip muscles
+#if BM_LEG_MORPHOLOGY == 1
+SartoriusProximal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+SartoriusDistal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+Sartorius1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 1
+IliacusLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusLateralis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusLateralis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMid2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMid3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+IliacusMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMedialis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMedialis3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+IliacusLateralis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusLateralis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+
+IliacusMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMid2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+IliacusMedialis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+
+IliacusMedialis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#endif
+
+PsoasMajor_PMT12I_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML1I_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML1T_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML2I_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML2T_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML3I_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML3T_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML4I_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML4T_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML5_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+PsoasMajor_PML5T_TM = {AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+GluteusMinimusAnterior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMinimusMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMinimusPosterior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusAnterior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusPosterior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusPosterior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusPosterior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusPosterior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//#if BM_LEG_MORPHOLOGY == 1
+GluteusMediusPosterior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMediusPosterior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+//#endif // TLEM1
+
+
+#if BM_LEG_MORPHOLOGY >= 2
+
+GluteusMaximusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#else
+
+#ifdef GLUTEUS_MAX_WRAPPING_BETA
+
+
+GluteusMaximusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior5 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+GluteusMaximusSuperior6 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+GluteusMaximusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior3 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+GluteusMaximusInferior4 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+GluteusMaximusInferior5 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+GluteusMaximusInferior6 = { AnyVar WeightFactor = WEIGHTFACTOR; }; 
+
+#else
+
+GluteusMaximusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusSuperior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+GluteusMaximusInferior4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GluteusMaximusInferior6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#endif
+
+#endif
+
+TensorFasciaeLatae1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+TensorFasciaeLatae2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Piriformis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Gracilis1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Gracilis2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+AdductorLongus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorLongus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorLongus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorLongus4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorLongus5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorLongus6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+//muscle changed to insert on thigh
+AdductorMagnusDistal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+AdductorMagnusDistal2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusDistal3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+AdductorMagnusMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusMid2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusMid3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusMid4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusMid5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusMid6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusProximal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusProximal2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusProximal3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorMagnusProximal4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisProximal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisProximal2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisMid1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisMid2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisDistal1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+AdductorBrevisDistal2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GemellusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+GemellusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#if BM_LEG_MORPHOLOGY == 1
+
+ObturatorExternusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+ObturatorInternus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+#if BM_LEG_MORPHOLOGY == 2
+ObturatorExternusSuperior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusSuperior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusSuperior3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusInferior1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorExternusInferior2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus5 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+ObturatorInternus6 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#endif
+
+
+Pectineus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Pectineus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Pectineus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Pectineus4 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+
+#if BM_FOOT_MODEL == _FOOT_MODEL_DEFAULT_
+#if BM_LEG_MORPHOLOGY == 1
+Plantaris1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+#if BM_LEG_MORPHOLOGY == 2
+Plantaris1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+#endif
+
+Popliteus1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+Popliteus2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+
+#if BM_LEG_MORPHOLOGY == 2
+Popliteus3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+#endif
+
+QuadratusFemoris1 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+QuadratusFemoris2 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+QuadratusFemoris3 = { AnyVar WeightFactor = WEIGHTFACTOR; };
+QuadratusFemoris4 = { AnyVar WeightFactor = WEIGHTFACTOR; };

--- a/Application/Examples/VolumeRecruitment/VolumeRecruitment.main.any
+++ b/Application/Examples/VolumeRecruitment/VolumeRecruitment.main.any
@@ -1,0 +1,29 @@
+#include "../libdef.any"
+
+Main = {
+
+#define BM_ARM_MUSCLES_LEFT OFF
+#define BM_ARM_MUSCLES_RIGHT OFF
+#define BM_TRUNK_MUSCLES OFF
+
+#include "<ANYBODY_PATH_BODY>/HumanModel.any"
+
+
+  #define WEIGHTFACTOR MusMdl.Vol0 
+  
+  Main.HumanModel.BodyModel.Right.Leg.Mus = {
+    #include "HookTLEMMuscles.any"
+  };  
+  Main.HumanModel.BodyModel.Left.Leg.Mus = {
+    #include "HookTLEMMuscles.any"
+  };
+
+  AnyBodyStudy Study = {
+     Gravity = {0, 0, -9.81};
+     AnyFolder& BodyModel = Main.HumanModel.BodyModel;
+     AnyFolder& DefaultDrivers = Main.HumanModel.DefaultMannequinDrivers;
+     
+     InverseDynamics.Criterion.PrimaryTerm.Weight_SearchName = "WeightFactor"; 
+  };
+
+};

--- a/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
+++ b/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
@@ -9,5 +9,14 @@
 // Enter and edit Lab-Specific Data in this file:
 #path MOCAP_LAB_SPECIFIC_DATA "Setup/LabSpecificData.any"
 
+#define INCLUDE_MUSCLE_WEIGHT_FACTOR 1
+Main = {
+   Main.Studies.InverseDynamicStudy = {
+     InverseDynamics.Criterion.PrimaryTerm.Weight_SearchName = "WeightFactor";
+   };
+};
+
 // Include the AnyMoCap Framwork
 #include "<ANYMOCAP_MODEL>"
+
+

--- a/Body/AAUHuman/LegTLEM/Mus.any
+++ b/Body/AAUHuman/LegTLEM/Mus.any
@@ -24,6 +24,7 @@ AnyMuscleViaPoint SoleusMedialis1 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusMedialis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SoleusMedialis2 = {
@@ -32,6 +33,7 @@ AnyMuscleViaPoint SoleusMedialis2 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusMedialis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SoleusMedialis3 = {
@@ -40,6 +42,7 @@ AnyMuscleViaPoint SoleusMedialis3 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusMedialis3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SoleusLateralis1 = {
@@ -48,6 +51,7 @@ AnyMuscleViaPoint SoleusLateralis1 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusLateralis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SoleusLateralis2 = {
@@ -56,6 +60,7 @@ AnyMuscleViaPoint SoleusLateralis2 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusLateralis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SoleusLateralis3 = {
@@ -64,6 +69,7 @@ AnyMuscleViaPoint SoleusLateralis3 = {
   AnyRefNode &Ins = ..Seg.Foot.SoleusLateralis3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #if BM_LEG_MORPHOLOGY == 1
@@ -78,6 +84,7 @@ AnyMuscleShortestPath GastrocnemiusLateralis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GastrocnemiusMedialis1 = {
@@ -91,7 +98,8 @@ AnyMuscleShortestPath GastrocnemiusMedialis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
-};  
+  #include "MusWeight.any"
+};
 #endif
 
 #if BM_LEG_MORPHOLOGY == 2
@@ -114,6 +122,7 @@ AnyMuscleShortestPath GastrocnemiusLateralis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GastrocnemiusMedialis1 = {
@@ -134,7 +143,8 @@ AnyMuscleShortestPath GastrocnemiusMedialis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
-};  
+  #include "MusWeight.any"
+};
 #endif
 
 
@@ -153,7 +163,8 @@ AnyMuscleViaPoint FlexorDigitorumLongus1 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorDigitorumLongus1Node;
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"};
-};  
+  #include "MusWeight.any"
+};
 
 AnyMuscleViaPoint FlexorDigitorumLongus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorDigitorumLongus2Par;
@@ -170,6 +181,7 @@ AnyMuscleViaPoint FlexorDigitorumLongus2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any" 
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint FlexorDigitorumLongus3 = {
@@ -187,6 +199,7 @@ AnyMuscleViaPoint FlexorDigitorumLongus3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any" 
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -206,7 +219,8 @@ AnyMuscleViaPoint FlexorDigitorumLongus1 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorDigitorumLongus1Node;
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"};
-};  
+  #include "MusWeight.any"
+};
 
 AnyMuscleViaPoint FlexorDigitorumLongus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorDigitorumLongus2Par;
@@ -223,7 +237,8 @@ AnyMuscleViaPoint FlexorDigitorumLongus2 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorDigitorumLongus2Node;
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"};
-}; 
+  #include "MusWeight.any"
+};
 
 AnyMuscleViaPoint FlexorDigitorumLongus3 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorDigitorumLongus3Par;
@@ -240,7 +255,9 @@ AnyMuscleViaPoint FlexorDigitorumLongus3 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorDigitorumLongus3Node;
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"};
-}; 
+  #include "MusWeight.any"
+};
+
 AnyMuscleViaPoint FlexorDigitorumLongus4 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorDigitorumLongus4Par;
   AnyRefNode &Org = ..Seg.Shank.FlexorDigitorumLongus4Node;
@@ -256,7 +273,8 @@ AnyMuscleViaPoint FlexorDigitorumLongus4 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorDigitorumLongus4Node;
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"};
-}; 
+  #include "MusWeight.any"
+};
 #endif
 
 #if BM_LEG_MORPHOLOGY == 1
@@ -273,6 +291,7 @@ AnyMuscleViaPoint FlexorHallucisLongus1 = {
   AnyRefNode &Via8 = ..Seg.Foot.FlexorHallucisLongusViaNode8;
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus1Node;
   AnyDrawMuscle DrwMus = { #include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint FlexorHallucisLongus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorHallucisLongus2Par;
@@ -288,6 +307,7 @@ AnyMuscleViaPoint FlexorHallucisLongus2 = {
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint FlexorHallucisLongus3 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorHallucisLongus3Par;
@@ -302,6 +322,7 @@ AnyMuscleViaPoint FlexorHallucisLongus3 = {
   AnyRefNode &Via8 = ..Seg.Foot.FlexorHallucisLongusViaNode8;
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 #endif
 
@@ -319,6 +340,7 @@ AnyMuscleViaPoint FlexorHallucisLongus1 = {
 //  AnyRefNode &Via8 = ..Seg.Foot.FlexorHallucisLongusViaNode8;
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus1Node;
   AnyDrawMuscle DrwMus = { #include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint FlexorHallucisLongus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorHallucisLongus2Par;
@@ -333,6 +355,7 @@ AnyMuscleViaPoint FlexorHallucisLongus2 = {
  // AnyRefNode &Via8 = ..Seg.Foot.FlexorHallucisLongusViaNode8;
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus2Node;
   AnyDrawMuscle DrwMus = { #include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint FlexorHallucisLongus3 = {
   AnyMuscleModel &MusMdl = ..MusPar.FlexorHallucisLongus3Par;
@@ -347,6 +370,7 @@ AnyMuscleViaPoint FlexorHallucisLongus3 = {
  // AnyRefNode &Via8 = ..Seg.Foot.FlexorHallucisLongusViaNode8;
   AnyRefNode &Ins = ..Seg.Foot.FlexorHallucisLongus3Node;
   AnyDrawMuscle DrwMus = { #include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 #endif
 
@@ -378,6 +402,7 @@ AnyMuscleViaPoint TibialisPosteriorLateralis1 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorLateralis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisPosteriorLateralis2 = {
@@ -407,6 +432,7 @@ AnyMuscleViaPoint TibialisPosteriorLateralis2 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorLateralis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisPosteriorLateralis3 = {
@@ -436,6 +462,7 @@ AnyMuscleViaPoint TibialisPosteriorLateralis3 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorLateralis3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisPosteriorMedialis1 = {
@@ -466,6 +493,7 @@ AnyMuscleViaPoint TibialisPosteriorMedialis1 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorMedialis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisPosteriorMedialis2 = {
@@ -496,6 +524,7 @@ AnyMuscleViaPoint TibialisPosteriorMedialis2 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorMedialis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisPosteriorMedialis3 = {
@@ -526,6 +555,7 @@ AnyMuscleViaPoint TibialisPosteriorMedialis3 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisPosteriorMedialis3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisAnterior1 = {
@@ -541,6 +571,7 @@ AnyMuscleViaPoint TibialisAnterior1 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisAnterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisAnterior2 = {
@@ -556,6 +587,7 @@ AnyMuscleViaPoint TibialisAnterior2 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisAnterior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TibialisAnterior3 = {
@@ -571,6 +603,7 @@ AnyMuscleViaPoint TibialisAnterior3 = {
   AnyRefNode &Ins = ..Seg.Foot.TibialisAnterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusBrevis1 = {
@@ -586,6 +619,7 @@ AnyMuscleViaPoint PeroneusBrevis1 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusBrevis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusBrevis2 = {
@@ -601,6 +635,7 @@ AnyMuscleViaPoint PeroneusBrevis2 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusBrevis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusBrevis3 = {
@@ -616,6 +651,7 @@ AnyMuscleViaPoint PeroneusBrevis3 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusBrevis2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusLongus1 = {
@@ -636,6 +672,7 @@ AnyMuscleViaPoint PeroneusLongus1 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusLongus1Node;
   AnyDrawMuscle DrwMus = { #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusLongus2 = {
@@ -656,6 +693,7 @@ AnyMuscleViaPoint PeroneusLongus2 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusLongus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusLongus3 = {
@@ -676,6 +714,7 @@ AnyMuscleViaPoint PeroneusLongus3 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusLongus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #if BM_LEG_MORPHOLOGY == 1
@@ -689,6 +728,7 @@ AnyMuscleViaPoint PeroneusTertius1 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusTertius1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusTertius2 = {
@@ -700,6 +740,7 @@ AnyMuscleViaPoint PeroneusTertius2 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusTertius2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint PeroneusTertius3 = {
@@ -711,6 +752,7 @@ AnyMuscleViaPoint PeroneusTertius3 = {
   AnyRefNode &Ins = ..Seg.Foot.PeroneusTertius3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -729,6 +771,7 @@ AnyMuscleViaPoint ExtensorDigitorumLongus1 = {
   AnyRefNode&Ins = ..Seg.Foot.ExtensorDigitorumLongus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint ExtensorDigitorumLongus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.ExtensorDigitorumLongus2Par;
@@ -745,6 +788,7 @@ AnyMuscleViaPoint ExtensorDigitorumLongus2 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorDigitorumLongus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 AnyMuscleViaPoint ExtensorDigitorumLongus3 = {
   AnyMuscleModel &MusMdl = ..MusPar.ExtensorDigitorumLongus3Par;
@@ -761,6 +805,7 @@ AnyMuscleViaPoint ExtensorDigitorumLongus3 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorDigitorumLongus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #if BM_LEG_MORPHOLOGY == 2
 AnyMuscleViaPoint ExtensorDigitorumLongus4 = {
@@ -776,6 +821,7 @@ AnyMuscleViaPoint ExtensorDigitorumLongus4 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorDigitorumLongus4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -802,6 +848,7 @@ AnyMuscleViaPoint ExtensorHallucisLongus1 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorHallucisLongus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ExtensorHallucisLongus2 = {
@@ -829,6 +876,7 @@ AnyMuscleViaPoint ExtensorHallucisLongus2 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorHallucisLongus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ExtensorHallucisLongus3 = {
@@ -856,6 +904,7 @@ AnyMuscleViaPoint ExtensorHallucisLongus3 = {
   AnyRefNode &Ins = ..Seg.Foot.ExtensorHallucisLongus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -890,6 +939,7 @@ AnyMuscleShortestPath VastusLateralisInferior1 = {
   
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisInferior2 = {
@@ -903,6 +953,7 @@ AnyMuscleShortestPath VastusLateralisInferior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisInferior3 = {
@@ -916,6 +967,7 @@ AnyMuscleShortestPath VastusLateralisInferior3 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisInferior4 = {
@@ -929,6 +981,7 @@ AnyMuscleShortestPath VastusLateralisInferior4 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisInferior5 = {
@@ -942,6 +995,7 @@ AnyMuscleShortestPath VastusLateralisInferior5 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisInferior6 = {
@@ -955,6 +1009,7 @@ AnyMuscleShortestPath VastusLateralisInferior6 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //VASTUS LATERALIS SUPERIOR WRAPPING
@@ -970,6 +1025,7 @@ AnyMuscleShortestPath VastusLateralisSuperior1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   }; 
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusLateralisSuperior2 = {
@@ -983,6 +1039,7 @@ AnyMuscleShortestPath VastusLateralisSuperior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //VASTUS MEDIALIS INFERIOR WRAPPING
@@ -998,6 +1055,7 @@ AnyMuscleShortestPath VastusMedialisInferior1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisInferior2 = {
@@ -1011,6 +1069,7 @@ AnyMuscleShortestPath VastusMedialisInferior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //VASTUS MEDIALIS MID WRAPPING
@@ -1026,6 +1085,7 @@ AnyMuscleShortestPath VastusMedialisMid1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisMid2 = {
@@ -1038,6 +1098,7 @@ AnyMuscleShortestPath VastusMedialisMid2 = {
     InitWrapPosVecArr =  ..VastusLateralisInferior1.SPLine.InitWrapPosVecArr;
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 
 //VASTUS MEDIALIS SUPERIOR WRAPPING
@@ -1053,6 +1114,7 @@ AnyMuscleShortestPath VastusMedialisSuperior1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisSuperior2 = {
@@ -1066,6 +1128,7 @@ AnyMuscleShortestPath VastusMedialisSuperior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisSuperior3 = {
@@ -1079,6 +1142,7 @@ AnyMuscleShortestPath VastusMedialisSuperior3 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisSuperior4 = {
@@ -1092,6 +1156,7 @@ AnyMuscleShortestPath VastusMedialisSuperior4 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #if BM_LEG_MORPHOLOGY == 1
@@ -1106,6 +1171,7 @@ AnyMuscleShortestPath VastusMedialisSuperior5 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusMedialisSuperior6 = {
@@ -1119,6 +1185,7 @@ AnyMuscleShortestPath VastusMedialisSuperior6 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -1135,6 +1202,7 @@ AnyMuscleShortestPath VastusIntermedius1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusIntermedius2 = {
@@ -1148,6 +1216,7 @@ AnyMuscleShortestPath VastusIntermedius2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusIntermedius3 = {
@@ -1161,6 +1230,7 @@ AnyMuscleShortestPath VastusIntermedius3 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusIntermedius4 = {
@@ -1174,6 +1244,7 @@ AnyMuscleShortestPath VastusIntermedius4 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusIntermedius5 = {
@@ -1187,6 +1258,7 @@ AnyMuscleShortestPath VastusIntermedius5 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath VastusIntermedius6 = {
@@ -1200,6 +1272,7 @@ AnyMuscleShortestPath VastusIntermedius6 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //RECTUS FEMORIS WRAPPING
@@ -1225,6 +1298,7 @@ AnyMuscleShortestPath RectusFemoris1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath RectusFemoris2 = {
@@ -1243,6 +1317,7 @@ SPLine = {
 
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1272,6 +1347,7 @@ AnyMuscleShortestPath Semitendinosus1 = {
     InitWrapPosVecArr = { &InitWrapPos, None};
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath Semimembranosus1 = {
@@ -1290,6 +1366,7 @@ AnyMuscleShortestPath Semimembranosus1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 AnyMuscleShortestPath Semimembranosus2 = {
   AnyMuscleModel &MusMdl = ..MusPar.Semimembranosus2Par;
@@ -1301,6 +1378,7 @@ AnyMuscleShortestPath Semimembranosus2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath Semimembranosus3 = {
@@ -1313,6 +1391,7 @@ AnyMuscleShortestPath Semimembranosus3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1335,6 +1414,7 @@ AnyMuscleShortestPath BicepsFemorisCaputLongum1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath BicepsFemorisCaputBreve1 = {
@@ -1352,6 +1432,7 @@ AnyMuscleShortestPath BicepsFemorisCaputBreve1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath BicepsFemorisCaputBreve2 = {
@@ -1363,6 +1444,7 @@ AnyMuscleShortestPath BicepsFemorisCaputBreve2 = {
   SPLine.InitWrapPosVecArr = .BicepsFemorisCaputBreve1.SPLine.InitWrapPosVecArr;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath BicepsFemorisCaputBreve3 = {
@@ -1374,6 +1456,7 @@ AnyMuscleShortestPath BicepsFemorisCaputBreve3 = {
   SPLine.InitWrapPosVecArr = .BicepsFemorisCaputBreve1.SPLine.InitWrapPosVecArr;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1398,6 +1481,7 @@ AnyMuscleViaPoint Semitendinosus1 = {
   AnyRefNode &Ins = ..Seg.Shank.Semitendinosus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Semimembranosus1 = {
@@ -1407,6 +1491,7 @@ AnyMuscleViaPoint Semimembranosus1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #if BM_LEG_MORPHOLOGY == 2
 AnyMuscleViaPoint Semimembranosus2 = {
@@ -1416,6 +1501,7 @@ AnyMuscleViaPoint Semimembranosus2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Semimembranosus3 = {
@@ -1425,6 +1511,7 @@ AnyMuscleViaPoint Semimembranosus3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -1435,6 +1522,7 @@ AnyMuscleViaPoint BicepsFemorisCaputLongum1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint BicepsFemorisCaputBreve1 = {
@@ -1443,6 +1531,7 @@ AnyMuscleViaPoint BicepsFemorisCaputBreve1 = {
   AnyRefNode &Ins = ..Seg.Shank.BicepsFemorisCaputBreve1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint BicepsFemorisCaputBreve2 = {
@@ -1451,6 +1540,7 @@ AnyMuscleViaPoint BicepsFemorisCaputBreve2 = {
   AnyRefNode &Ins = ..Seg.Shank.BicepsFemorisCaputBreve2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint BicepsFemorisCaputBreve3 = {
@@ -1459,6 +1549,7 @@ AnyMuscleViaPoint BicepsFemorisCaputBreve3 = {
   AnyRefNode &Ins = ..Seg.Shank.BicepsFemorisCaputBreve3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #endif
@@ -1487,6 +1578,7 @@ AnyMuscleViaPoint SartoriusProximal1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint SartoriusDistal1 = {
@@ -1497,6 +1589,7 @@ AnyMuscleViaPoint SartoriusDistal1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -1517,6 +1610,7 @@ AnyMuscleViaPoint Sartorius1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -1543,6 +1637,7 @@ AnyMuscleShortestPath IliacusLateralis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1559,6 +1654,7 @@ AnyMuscleShortestPath IliacusLateralis2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1575,6 +1671,7 @@ AnyMuscleShortestPath IliacusLateralis3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1591,6 +1688,7 @@ AnyMuscleShortestPath IliacusMid1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1607,6 +1705,7 @@ AnyMuscleShortestPath IliacusMid2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1623,6 +1722,7 @@ AnyMuscleShortestPath IliacusMid3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1638,6 +1738,7 @@ AnyMuscleShortestPath IliacusMedialis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1654,6 +1755,7 @@ AnyMuscleShortestPath IliacusMedialis2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1670,6 +1772,7 @@ AnyMuscleShortestPath IliacusMedialis3 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -1692,6 +1795,7 @@ AnyMuscleShortestPath IliacusLateralis1 = {
     AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1707,6 +1811,7 @@ AnyMuscleShortestPath IliacusLateralis2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1723,6 +1828,7 @@ AnyMuscleShortestPath IliacusMid1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1738,6 +1844,7 @@ AnyMuscleShortestPath IliacusMid2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1752,6 +1859,7 @@ AnyMuscleShortestPath IliacusMedialis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -1767,6 +1875,7 @@ AnyMuscleShortestPath IliacusMedialis2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #endif
@@ -1782,6 +1891,17 @@ AnyMuscle &PsoasMajor_PML4I_TM = .TrunkMuscles.PsoasMajor.PML4I_TM;//< Psoas mus
 AnyMuscle &PsoasMajor_PML4T_TM = .TrunkMuscles.PsoasMajor.PML4T_TM;//< Psoas muscles are created by the Trunk model
 AnyMuscle &PsoasMajor_PML5_TM = .TrunkMuscles.PsoasMajor.PML5_TM;//< Psoas muscles are created by the Trunk model
 AnyMuscle &PsoasMajor_PML5T_TM = .TrunkMuscles.PsoasMajor.PML5T_TM;//< Psoas muscles are created by the Trunk model
+PsoasMajor_PMT12I_TM = {#include "MusWeight.any"};
+PsoasMajor_PML1I_TM = {#include "MusWeight.any"};
+PsoasMajor_PML1T_TM = {#include "MusWeight.any"};
+PsoasMajor_PML2I_TM = {#include "MusWeight.any"};
+PsoasMajor_PML2T_TM = {#include "MusWeight.any"};
+PsoasMajor_PML3I_TM = {#include "MusWeight.any"};
+PsoasMajor_PML3T_TM = {#include "MusWeight.any"};
+PsoasMajor_PML4I_TM = {#include "MusWeight.any"};
+PsoasMajor_PML4T_TM = {#include "MusWeight.any"};
+PsoasMajor_PML5_TM = {#include "MusWeight.any"};
+PsoasMajor_PML5T_TM = {#include "MusWeight.any"};
 
 
 AnyMuscleViaPoint GluteusMinimusAnterior1 = {
@@ -1793,6 +1913,7 @@ AnyMuscleViaPoint GluteusMinimusAnterior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMinimusAnterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMinimusMid1 = {
@@ -1804,6 +1925,7 @@ AnyMuscleViaPoint GluteusMinimusMid1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMinimusMid1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMinimusPosterior1 = {
@@ -1815,6 +1937,7 @@ AnyMuscleViaPoint GluteusMinimusPosterior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMinimusPosterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior1 = {
@@ -1823,6 +1946,7 @@ AnyMuscleViaPoint GluteusMediusAnterior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior2 = {
@@ -1831,6 +1955,7 @@ AnyMuscleViaPoint GluteusMediusAnterior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior3 = {
@@ -1839,6 +1964,7 @@ AnyMuscleViaPoint GluteusMediusAnterior3 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior4 = {
@@ -1847,6 +1973,7 @@ AnyMuscleViaPoint GluteusMediusAnterior4 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior5 = {
@@ -1855,6 +1982,7 @@ AnyMuscleViaPoint GluteusMediusAnterior5 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior6 = {
@@ -1863,6 +1991,7 @@ AnyMuscleViaPoint GluteusMediusAnterior6 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior1 = {
@@ -1871,6 +2000,7 @@ AnyMuscleViaPoint GluteusMediusPosterior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior2 = {
@@ -1879,6 +2009,7 @@ AnyMuscleViaPoint GluteusMediusPosterior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior3 = {
@@ -1887,6 +2018,7 @@ AnyMuscleViaPoint GluteusMediusPosterior3 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior4 = {
@@ -1895,6 +2027,7 @@ AnyMuscleViaPoint GluteusMediusPosterior4 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //#if BM_LEG_MORPHOLOGY == 1
@@ -1904,6 +2037,7 @@ AnyMuscleViaPoint GluteusMediusPosterior5 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior6 = {
@@ -1912,6 +2046,7 @@ AnyMuscleViaPoint GluteusMediusPosterior6 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 //#endif // TLEM1
 
@@ -1939,6 +2074,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior2 = {
@@ -1961,6 +2097,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior3 = {
@@ -1982,6 +2119,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior3 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior4 = {
@@ -2003,6 +2141,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior4 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior5 = {
@@ -2025,6 +2164,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior5 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior6 = {
@@ -2046,6 +2186,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior6 = {
     InitWrapPosVecArr = { &InitWrapPos};
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior1 = {
@@ -2067,6 +2208,7 @@ AnyMuscleShortestPath GluteusMaximusInferior1 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior2 = {
@@ -2088,6 +2230,7 @@ AnyMuscleShortestPath GluteusMaximusInferior2 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior3 = {
@@ -2109,6 +2252,7 @@ AnyMuscleShortestPath GluteusMaximusInferior3 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior4 = {
@@ -2130,6 +2274,7 @@ AnyMuscleShortestPath GluteusMaximusInferior4 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior5 = {
@@ -2151,6 +2296,7 @@ AnyMuscleShortestPath GluteusMaximusInferior5 = {
   };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior6 = {
@@ -2167,10 +2313,11 @@ AnyMuscleShortestPath GluteusMaximusInferior6 = {
         transf3D({ -0.37*.srf.Radius, ...Sign*1.04*.srf.Radius, 0.6*.srf.Length }, &.srf ),
         transf3D({ -0.78*.srf.Radius, ...Sign*0.78*.srf.Radius, 0.6*.srf.Length }, &.srf ), 
         transf3D({ -.srf.Radius, ...Sign*0.38*.srf.Radius, 0.6*.srf.Length }, &.srf ) 
-  };
+    };
     InitWrapPosVecArr = { &InitWrapPos};
-};
+  };
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any" };
+  #include "MusWeight.any"
 };
 
 #else
@@ -2187,6 +2334,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior1 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior2 = {
@@ -2198,6 +2346,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior2 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior3 = {
@@ -2209,6 +2358,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior3 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior4 = {
@@ -2220,6 +2370,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior4 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusSuperior5 = {
@@ -2231,6 +2382,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior5 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 }; 
 
 AnyMuscleShortestPath GluteusMaximusSuperior6 = {
@@ -2241,6 +2393,7 @@ AnyMuscleShortestPath GluteusMaximusSuperior6 = {
   SPLine.StringMesh = 100;
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
+  #include "MusWeight.any"
 }; 
 
 AnyMuscleShortestPath GluteusMaximusInferior1 = {
@@ -2252,6 +2405,7 @@ AnyMuscleShortestPath GluteusMaximusInferior1 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior2 = {
@@ -2263,6 +2417,7 @@ AnyMuscleShortestPath GluteusMaximusInferior2 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleShortestPath GluteusMaximusInferior3 = {
@@ -2274,6 +2429,7 @@ AnyMuscleShortestPath GluteusMaximusInferior3 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 }; 
 
 AnyMuscleShortestPath GluteusMaximusInferior4 = {
@@ -2285,6 +2441,7 @@ AnyMuscleShortestPath GluteusMaximusInferior4 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 }; 
 
 AnyMuscleShortestPath GluteusMaximusInferior5 = {
@@ -2296,6 +2453,7 @@ AnyMuscleShortestPath GluteusMaximusInferior5 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 }; 
 
 AnyMuscleShortestPath GluteusMaximusInferior6 = {
@@ -2307,6 +2465,7 @@ AnyMuscleShortestPath GluteusMaximusInferior6 = {
   SPLine.InitWrapPosVectors = {{0,0,0},{-0.5, 0.5 ,0}};
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 }; 
 
 #else
@@ -2317,6 +2476,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusSuperior2 = {
@@ -2325,6 +2485,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusSuperior3 = {
@@ -2333,6 +2494,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior3 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusSuperior4 = {
@@ -2341,6 +2503,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior4 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusSuperior5 = {
@@ -2349,6 +2512,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior5 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusSuperior6 = {
@@ -2357,6 +2521,7 @@ AnyMuscleViaPoint GluteusMaximusSuperior6 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusSuperior6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"};
   
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusInferior1 = {
@@ -2365,6 +2530,7 @@ AnyMuscleViaPoint GluteusMaximusInferior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusInferior2 = {
@@ -2373,6 +2539,7 @@ AnyMuscleViaPoint GluteusMaximusInferior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusInferior3 = {
@@ -2381,6 +2548,7 @@ AnyMuscleViaPoint GluteusMaximusInferior3 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2390,6 +2558,7 @@ AnyMuscleViaPoint GluteusMaximusInferior4 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusInferior5 = {
@@ -2398,6 +2567,7 @@ AnyMuscleViaPoint GluteusMaximusInferior5 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GluteusMaximusInferior6 = {
@@ -2406,6 +2576,7 @@ AnyMuscleViaPoint GluteusMaximusInferior6 = {
   AnyRefNode &Ins = ..Seg.Thigh.GluteusMaximusInferior6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"  
   };
+  #include "MusWeight.any"
 };
 
 #endif
@@ -2421,6 +2592,7 @@ AnyMuscleViaPoint TensorFasciaeLatae1 = {
   AnyRefNode &Ins = ..Seg.Shank.TensorFasciaeLatae1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint TensorFasciaeLatae2 = {
@@ -2432,6 +2604,7 @@ AnyMuscleViaPoint TensorFasciaeLatae2 = {
   AnyRefNode &Ins = ..Seg.Shank.TensorFasciaeLatae2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Piriformis1 = {
@@ -2440,6 +2613,7 @@ AnyMuscleViaPoint Piriformis1 = {
   AnyRefNode &Ins = ..Seg.Thigh.Piriformis1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Gracilis1 = {
@@ -2461,6 +2635,7 @@ AnyMuscleViaPoint Gracilis1 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Gracilis2 = {
@@ -2482,6 +2657,7 @@ AnyMuscleViaPoint Gracilis2 = {
   AnyDrawMuscle DrwMus = {
     #include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2491,6 +2667,7 @@ AnyMuscleViaPoint AdductorLongus1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };  
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorLongus2 = {
@@ -2499,6 +2676,7 @@ AnyMuscleViaPoint AdductorLongus2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorLongus3 = {
@@ -2507,6 +2685,7 @@ AnyMuscleViaPoint AdductorLongus3 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorLongus4 = {
@@ -2515,6 +2694,7 @@ AnyMuscleViaPoint AdductorLongus4 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorLongus5 = {
@@ -2523,6 +2703,7 @@ AnyMuscleViaPoint AdductorLongus5 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorLongus6 = {
@@ -2531,6 +2712,7 @@ AnyMuscleViaPoint AdductorLongus6 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorLongus6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //muscle changed to insert on thigh
@@ -2540,6 +2722,7 @@ AnyMuscleViaPoint AdductorMagnusDistal1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusDistal1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2550,6 +2733,7 @@ AnyMuscleViaPoint AdductorMagnusDistal2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusDistal2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 //muscle changed to insert on thigh
 AnyMuscleViaPoint AdductorMagnusDistal3 = {
@@ -2558,6 +2742,7 @@ AnyMuscleViaPoint AdductorMagnusDistal3 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusDistal3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2567,6 +2752,7 @@ AnyMuscleViaPoint AdductorMagnusMid1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusMid2 = {
@@ -2575,6 +2761,7 @@ AnyMuscleViaPoint AdductorMagnusMid2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusMid3 = {
@@ -2583,6 +2770,7 @@ AnyMuscleViaPoint AdductorMagnusMid3 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusMid4 = {
@@ -2591,6 +2779,7 @@ AnyMuscleViaPoint AdductorMagnusMid4 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusMid5 = {
@@ -2599,6 +2788,7 @@ AnyMuscleViaPoint AdductorMagnusMid5 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid5Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusMid6 = {
@@ -2607,6 +2797,7 @@ AnyMuscleViaPoint AdductorMagnusMid6 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusMid6Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusProximal1 = {
@@ -2615,6 +2806,7 @@ AnyMuscleViaPoint AdductorMagnusProximal1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusProximal1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusProximal2 = {
@@ -2623,6 +2815,7 @@ AnyMuscleViaPoint AdductorMagnusProximal2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusProximal2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusProximal3 = {
@@ -2631,6 +2824,7 @@ AnyMuscleViaPoint AdductorMagnusProximal3 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusProximal3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorMagnusProximal4 = {
@@ -2639,6 +2833,7 @@ AnyMuscleViaPoint AdductorMagnusProximal4 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorMagnusProximal4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisProximal1 = {
@@ -2647,6 +2842,7 @@ AnyMuscleViaPoint AdductorBrevisProximal1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisProximal1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisProximal2 = {
@@ -2655,6 +2851,7 @@ AnyMuscleViaPoint AdductorBrevisProximal2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisProximal2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisMid1 = {
@@ -2663,6 +2860,7 @@ AnyMuscleViaPoint AdductorBrevisMid1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisMid1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisMid2 = {
@@ -2671,6 +2869,7 @@ AnyMuscleViaPoint AdductorBrevisMid2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisMid2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisDistal1 = {
@@ -2679,6 +2878,7 @@ AnyMuscleViaPoint AdductorBrevisDistal1 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisDistal1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint AdductorBrevisDistal2 = {
@@ -2687,6 +2887,7 @@ AnyMuscleViaPoint AdductorBrevisDistal2 = {
   AnyRefNode &Ins = ..Seg.Thigh.AdductorBrevisDistal2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GemellusInferior1 = {
@@ -2695,6 +2896,7 @@ AnyMuscleViaPoint GemellusInferior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GemellusInferior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint GemellusSuperior1 = {
@@ -2703,6 +2905,7 @@ AnyMuscleViaPoint GemellusSuperior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.GemellusSuperior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #if BM_LEG_MORPHOLOGY == 1
@@ -2714,6 +2917,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorExternusSuperior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusSuperior2 = {
@@ -2723,6 +2927,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorExternusSuperior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusSuperior3 = {
@@ -2732,6 +2937,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior3 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorExternusSuperior3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusInferior1 = {
@@ -2740,6 +2946,7 @@ AnyMuscleViaPoint ObturatorExternusInferior1 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorExternusInferior1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusInferior2 = {
@@ -2748,6 +2955,7 @@ AnyMuscleViaPoint ObturatorExternusInferior2 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorExternusInferior2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus1 = {
@@ -2757,6 +2965,7 @@ AnyMuscleViaPoint ObturatorInternus1 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2767,6 +2976,7 @@ AnyMuscleViaPoint ObturatorInternus2 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus3 = {
@@ -2776,6 +2986,7 @@ AnyMuscleViaPoint ObturatorInternus3 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -2787,6 +2998,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior1 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorExternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusSuperior2 = {
@@ -2796,6 +3008,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior2 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorExternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusSuperior3 = {
@@ -2805,6 +3018,7 @@ AnyMuscleViaPoint ObturatorExternusSuperior3 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorExternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusInferior1 = {
@@ -2814,6 +3028,7 @@ AnyMuscleViaPoint ObturatorExternusInferior1 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorExternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorExternusInferior2 = {
@@ -2823,6 +3038,7 @@ AnyMuscleViaPoint ObturatorExternusInferior2 = {
   AnyRefNode &Ins =  ..Seg.Thigh.ObturatorExternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus1 = {
@@ -2832,6 +3048,7 @@ AnyMuscleViaPoint ObturatorInternus1 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus2 = {
@@ -2841,6 +3058,7 @@ AnyMuscleViaPoint ObturatorInternus2 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus3 = {
@@ -2850,6 +3068,7 @@ AnyMuscleViaPoint ObturatorInternus3 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus4 = {
@@ -2859,6 +3078,7 @@ AnyMuscleViaPoint ObturatorInternus4 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus5 = {
@@ -2868,6 +3088,7 @@ AnyMuscleViaPoint ObturatorInternus5 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint ObturatorInternus6 = {
@@ -2877,6 +3098,7 @@ AnyMuscleViaPoint ObturatorInternus6 = {
   AnyRefNode &Ins = ..Seg.Thigh.ObturatorInternus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 #endif
@@ -2892,6 +3114,7 @@ AnyMuscleViaPoint Pectineus1 =
   AnyRefNode &Ins = ..Seg.Thigh.Pectineus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Pectineus2 = {
@@ -2900,6 +3123,7 @@ AnyMuscleViaPoint Pectineus2 = {
   AnyRefNode &Ins = ..Seg.Thigh.Pectineus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Pectineus3 = {
@@ -2908,6 +3132,7 @@ AnyMuscleViaPoint Pectineus3 = {
   AnyRefNode &Ins = ..Seg.Thigh.Pectineus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Pectineus4 = {
@@ -2916,6 +3141,7 @@ AnyMuscleViaPoint Pectineus4 = {
   AnyRefNode &Ins = ..Seg.Thigh.Pectineus4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 
@@ -2927,6 +3153,7 @@ AnyMuscleViaPoint Plantaris1 = {
   AnyRefNode &Ins = ..Seg.Foot.Plantaris1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 #if BM_LEG_MORPHOLOGY == 2
@@ -2944,6 +3171,7 @@ AnyMuscleShortestPath Plantaris1 = {
   AnyRefNode &Ins = ..Seg.Foot.Plantaris1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 #endif
@@ -2958,6 +3186,7 @@ AnyMuscleViaPoint Popliteus1 = {
   AnyRefNode &Ins = ..Seg.Shank.Popliteus1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint Popliteus2 = {
@@ -2970,6 +3199,7 @@ AnyMuscleViaPoint Popliteus2 = {
   AnyRefNode &Ins = ..Seg.Shank.Popliteus2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 //-->ABT_MJ
@@ -2982,6 +3212,7 @@ AnyMuscleViaPoint Popliteus3 = {
   AnyRefNode &Ins = ..Seg.Shank.Popliteus3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 #endif
 
@@ -2991,6 +3222,7 @@ AnyMuscleViaPoint QuadratusFemoris1 = {
   AnyRefNode &Ins = ..Seg.Thigh.QuadratusFemoris1Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint QuadratusFemoris2 = {
@@ -2999,6 +3231,7 @@ AnyMuscleViaPoint QuadratusFemoris2 = {
   AnyRefNode &Ins = ..Seg.Thigh.QuadratusFemoris2Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint QuadratusFemoris3 = {
@@ -3007,6 +3240,7 @@ AnyMuscleViaPoint QuadratusFemoris3 = {
   AnyRefNode &Ins = ..Seg.Thigh.QuadratusFemoris3Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };
 
 AnyMuscleViaPoint QuadratusFemoris4 = {
@@ -3015,4 +3249,5 @@ AnyMuscleViaPoint QuadratusFemoris4 = {
   AnyRefNode &Ins = ..Seg.Thigh.QuadratusFemoris4Node;
   AnyDrawMuscle DrwMus = {#include "../DrawSettings/MusDrawSettings.any"
   };
+  #include "MusWeight.any"
 };

--- a/Body/AAUHuman/LegTLEM/MusWeight.any
+++ b/Body/AAUHuman/LegTLEM/MusWeight.any
@@ -1,0 +1,24 @@
+#ifdef INCLUDE_MUSCLE_WEIGHT_FACTOR 
+
+#if INCLUDE_MUSCLE_WEIGHT_FACTOR == 1
+AnyVar WeightFactor = (1.0/MusMdl.MuscleElemNo);
+#endif
+#if INCLUDE_MUSCLE_WEIGHT_FACTOR > 1
+AnyVar WeightFactor = (MusMdl.Vol0);
+#endif
+
+//// The code below was used when no volumes where available in the muscle models
+// #if INCLUDE_MUSCLE_WEIGHT_FACTOR > 2
+// // F0/PCSAFactor = PCSA... This version is used when the simple muscles are used
+// //AnyVar WeightFactor = (MusMdl.F0/..MusPar.PCSAfactor)^(1.0/p);
+// AnyVar WeightFactor = (MusMdl.Vol0)^(1.0/p);
+// #endif
+// #if INCLUDE_MUSCLE_WEIGHT_FACTOR == 3
+//   // F0*LfBar/(PCSAFactor) = PCSA*LfBar = Volumen... This version is used when the 3E muscles are used
+//  AnyVar WeightFactor = (MusMdl.F0*MusMdl.Lfbar/..MusPar.PCSAfactor)^(1.0/p);
+// #endif
+
+
+
+#endif
+


### PR DESCRIPTION
In GitLab by @melund on Oct 1, 2019, 15:39

This is an example of creating a simple volume weighted muscle recruitment.

The implementation is a hack because the we need to add "WeightFactor" variable to each muscle in the TLEM2 leg. 

This is done because the weights must be located in the main folder of the muscle, while the volume is currently stored in the muscle model. And since the muscle only has reference to the muscle model volume can't be found. 

The weight factor is set to `AnyVar WeightFactor = MusMdl.Vol0`. Finally it is added to the recruitment using

```
InverseDynamics.Criterion.PrimaryTerm.Weight_SearchName = "WeightFactor";
```