### PR TITLE
Use new anyset "Save design" class operation in AnyMocap

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ AMMR beta
   would slide off the wrapping surface representing the thorax segment.  
 * Renamed all deprecated muscles class names. ``AnyViaPointMuscle``->:ref:`AnyMuscleViaPoint`
   and ``AnyShortestPathMuscle``->:ref:`AnyMuscleShortestPath`
+* The AnyMoCap framework uses a more robust way of saving optimized parameters from the parameter optimization studies, when using AMS 7.3.
 * Changed the format used by the AnyMoCap models when transferring joint angles from the Marker tracking step to 
   to inverse dynamics simulation.
   The joint-angles for the arms and pelvis rotation are now written in terms of rotation vectors instead of Euler angles. This fixes 
@@ -82,7 +83,7 @@ AMMR beta
 
 * Added new rotation vector based measures in the interface folder for the arm degrees of freedom.
   These measures (``Interface.Right.RotVectorMeasures.*```) for joint angles do not have a clinical
-  meaning but are use full when exporting and importing joint angles. 
+  meaning but are use full when exporting and importing joint angles.
 
 * Added a new :ammr:bm_statement:`option for setting custom muscle calibration <BM_CALIBRATION_TYPE>`. 
   I.e. a option which disables calibration so the user can add their own code. 

--- a/Tools/AnyMocap/SaveLoadParameters.any
+++ b/Tools/AnyMocap/SaveLoadParameters.any
@@ -1,5 +1,17 @@
-  Main.ModelSetup.Macros = {     
-
+  Main.ModelSetup.Macros = {   
+   
+   #ifndef MOCAP_PARAMETER_FILE_PREFIX
+   #define MOCAP_PARAMETER_FILE_PREFIX MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX
+   #endif
+      
+   #if (ANYBODY_V1 > 7)|(ANYBODY_V1 == 7 & ANYBODY_V2 > 2)
+   AnyOperationMacro Save_parameters = {
+     AnyFileVar SavePath = TEMP_PATH;
+     MacroStr  = {"classoperation Main" + strquote("Save Values") +"--file=" + 
+       strquote(FilePathCompleteOf(SavePath) +"/"+  MOCAP_PARAMETER_FILE_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName +".anyset" )    
+     };
+   };
+   #else
    AnyOperationSequence Save_parameters= {
      OPERATION_DISPLAY_PRIORITY(PriorityLow);
      // This operation uses `AnyOperationSetValue` to mark all values that must be saved 
@@ -29,20 +41,16 @@
           
         Target = Source;
       };   
-      
-      
-      #ifndef MOCAP_PARAMETER_FILE_PREFIX
-      #define MOCAP_PARAMETER_FILE_PREFIX MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX
-      #endif
-      
+            
       AnyOperationMacro SaveToFile = {
         AnyFileVar SavePath = TEMP_PATH;
         MacroStr  = {"classoperation Main" + strquote("Save Values") +"--file=" + 
           strquote(FilePathCompleteOf(SavePath) +"/"+  MOCAP_PARAMETER_FILE_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName +".anyset" )
         };
-        
       };
     };
+    #endif
+      
     #if MOCAP_CREATE_PARAMETER_ID_SHORTCUT
     Main.RunParameterIdentification.SaveParameters = {
       AnyOperation &Save_parameters_to_anyset = Main.ModelSetup.Macros.Save_parameters;


### PR DESCRIPTION
This uses a new AMS 7.3 feature to save optimized parameters to AnySet file with the "Save design" class operation. 

The previous implementation (or hack) is till in the code to keep backwards compatibility. 