### PR TITLE
Fixed the load-time position of the head segment

### DIFF
--- a/Body/AAUHuman/Trunk/SegmentsThorax.any
+++ b/Body/AAUHuman/Trunk/SegmentsThorax.any
@@ -35,7 +35,9 @@ AnyFolder SegmentsThorax = {
     
     AnyFunTransform3D &Scale =..ScalingTrunk.SkullSeg.ScaleFunction;
     
-    r0=.ThoraxSeg.C1HatNode.sRel*.ThoraxSeg.Axes0'+.ThoraxSeg.r0; 
+    r0=..SegmentsCervicalSpine.C1Seg.C1C0JntNode.sRel*..SegmentsCervicalSpine.C1Seg.Axes0'
+       +..SegmentsCervicalSpine.C1Seg.r0
+       + C1C0JntNode.sRel*Axes0; 
     
     AnyVar MassS = ..Scaling.MassScaling.Head.MassScale;
     

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ AMMR beta
   :ref:`evaluate arm joint strength <sphx_glr_auto_examples_validation_plot_evaluatejointstrength_py>`. 
   The range of motion for the left arm elbow pronation/supination were not correct. 
 * Fixed a bug preventing the model from loading with with :bm_constant:`_SCALING_XYZ_` and both legs excluded. 
+* Fixed the load-time position of the head segment when neck scaling is changed.
 
 **Changed:**
 


### PR DESCRIPTION
It now respect changes to neck length scaling and appears in the correct position on load.

Thanks a lot @Kristofferiversen for spotting this.