### PR TITLE
Fix missing logo on Jumping Jack model.

### DIFF
--- a/Application/Examples/JumpingJack/JumpingJack.main.any
+++ b/Application/Examples/JumpingJack/JumpingJack.main.any
@@ -202,7 +202,7 @@ Main = {
           r0 = {0, -0.12, 0.0045};
           Axes0 = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
           AnyDrawSTL Body = {
-            FileName = "<ANYBODY_PATH_MODELUTILS>/DrawObjects/Body-grey.stl";
+            FileName = ANYBODY_PATH_MODELUTILS + "/DrawObjects/Body-grey.stl";
             RGB = ..DrawSettings.Colors.AnyBodyRed;
             
             ScaleXYZ={0.002,0.002,0.002};
@@ -210,7 +210,7 @@ Main = {
           };
           
           AnyDrawSTL AnyTechnology = {
-            FileName = "<ANYBODY_PATH_MODELUTILS>/DrawObjects/AnyTechnology-red.stl";
+            FileName = ANYBODY_PATH_MODELUTILS + "/DrawObjects/AnyTechnology-red.stl";
             RGB = ..DrawSettings.Colors.AnyBodyGrey;
             
             ScaleXYZ={0.002,0.002,0.002};


### PR DESCRIPTION
The missing logo was caused by a syntax typo, which was no
longer silent in AMS 7.3

![image](https://user-images.githubusercontent.com/1038978/86249269-54869b00-bbaf-11ea-9883-bf36b1dc3007.png)
