### PR TITLE
moved ignore_errors statement to AnyPyProcess

### DIFF
--- a/Application/MocapExamples/ADL_Gait_[beta]/batchprocess.py
+++ b/Application/MocapExamples/ADL_Gait_[beta]/batchprocess.py
@@ -67,10 +67,9 @@ macro = [
     mc.OperationRun("Main.RunAnalysis.MarkerTracking"),
 ]
 
-app = AnyPyProcess()
+app = AnyPyProcess(ignore_errors=[".anyset"],)
 app.start_macro(
     macro,
-    ignore_errors=[".anyset"],
     search_subdirs=r"\d{7}_C\d_\d\d\\Main.any",
     logfile="BatchProcessingLogs/MarkerTracking.txt",
 )


### PR DESCRIPTION
We had missed to move the statement to ignore errors for unused variables in the anyset files.