### PR TITLE
revert torus rotation

### DIFF
--- a/Body/AAUHuman/Arm/HumerusMuscleGeometry.any
+++ b/Body/AAUHuman/Arm/HumerusMuscleGeometry.any
@@ -85,7 +85,7 @@ Humerus = {
     AnyVar major_radius = minor_radius*1.9;
 
     AnyVec3 minor_center = {0, .I_teres_minor_3.sRel[1],0};
-    AnyMat33 orientation = RotMat(-1.2*...Sign,y);
+    AnyMat33 orientation = RotMat(0.0*...Sign,y);
     
     AnyVec3 major_center = minor_center+major_radius*...Sign*orientation'[0];
         


### PR DESCRIPTION
Changed torus rotation to avoid strange moment arm in some arm positions, on the pic one of the teres_minor muscles are using old torus, the blue lines are using new torus orientation.

![image](https://user-images.githubusercontent.com/1162500/94541626-151c2900-0248-11eb-8fb4-84d0581821c0.png)

