### PR TITLE
Update CHANGELOG.txt

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,9 +23,9 @@ AMMR 2.3.2 (2021-01-21)
 .. rst-class:: without-title
 .. warning:: **Model results can change!**
 
-   A bug related to scaling was fixed in AMMR 2.3.2. This affect models using
+   A bug related to scaling was fixed in AMMR 2.3.2. This affect models using the
    :bm_constant:`length-mass-fat<_SCALING_LENGTHMASSFAT_>` and
-   :bm_constant:`uniform <_SCALING_UNIFORM_>` when only Body Height is
+   :bm_constant:`uniform <_SCALING_UNIFORM_>` scaling, when only Body Height is
    specified. The results can change as models more accurately match the
    requested body height.
 
@@ -38,7 +38,7 @@ AMMR 2.3.2 (2021-01-21)
   Hospital Basel for fixing this issue. 
 
 * Fixed a bug when using :bm_constant:`_SCALING_LENGTHMASSFAT_` and  :bm_constant:`_SCALING_UNIFORM_`
-  and only specifying the body height as input. The segment length were set to
+  and only specifying the body height as input. The segment lengths were set to
   slightly smaller values, which caused the total body height to be less than
   what was used as input. The bug occurred since a standard body height in some
   'AnyMan' files was assumed to be 1.8 m instead of the correct 1.75 m. This fix
@@ -71,7 +71,7 @@ AMMR 2.3.2 (2021-01-21)
   high arm postures.
 
 * Fix problem with latissimus dorsi muscle wrapping in over-head arm postures. A
-  new wrapping ellipsoid has been added at humeral head.
+  new wrapping ellipsoid has been added at the humeral head.
 
 **Changed:**
 
@@ -84,7 +84,7 @@ AMMR 2.3.2 (2021-01-21)
 
 * The results for the :ref:`"Wilke Spine Pressure"
   <sphx_glr_auto_examples_Validation_plot_WilkeSpinePressure.py>` 
-  validation model has been updated due to the fix
+  validation model has been updated due to the fix for the
   :bm_constant:`_SCALING_UNIFORM_`. The updated model improved the validation
   results slightly. 
 
@@ -94,17 +94,17 @@ AMMR 2.3.2 (2021-01-21)
   if the user forgets to first run the standing reference trials. It is still 
   necessary to run the standing reference trials again if any changes are made to the model. 
 
-* The wrapping for Triceps Long Head has been updated at the humeral head
+* The wrapping for the "Triceps Long Head" muscle has been updated at the humeral head
   to avoid the muscle wrapping incorrectly in over-head arm postures. This fix 
-  also adds a via point at the middle of the humerus to make wrapping solution
+  also adds a via point at the middle of the humerus to make the wrapping solution
   more robust. 
 
 * The ``VideoLookAtCamera`` camera class template in the AMMR now saves videos as they look in
   the model view. I.e. if things are hidden in the model view they will not show up in the video.
   This feature is enabled by a new setting :ref:`AnyCameraLookAt.RenderUserInterfaceViewState` in 
   AnyBody version 7.3.2. The old behavior can be restored by setting ``Camera.RenderUserInterfaceViewState=Off;`` 
-  in the class template. 
-
+  in the class template.
+  
 
 **************************
 AMMR 2.3.1 (2020-09-30) 


### PR DESCRIPTION
Proof reading

This reference on line 105  does not resolve to a link - maybe just because the ref manual is not updated yet?
``` 
:ref:`AnyCameraLookAt.RenderUserInterfaceViewState`
````
