### PR TITLE
Change StringMesh AnyVar to AnyIntVar

### DIFF
--- a/Body/AAUHuman/Trunk/PsoasMajorLeft.any
+++ b/Body/AAUHuman/Trunk/PsoasMajorLeft.any
@@ -6,7 +6,7 @@ Mark de Zee (23-04-2003)
 
 AnyFolder PsoasMajor = {
   
-  AnyVar StringMesh=15;
+  AnyIntVar StringMesh=15;
   
   AnyMuscleShortestPath PMT12I_TM = {
     AnyMuscleModel &MusMdl = ...MuscleParametersSpineLeft.PsoasMajorParameter.PMT12I_TMPar;

--- a/Body/AAUHuman/Trunk/PsoasMajorRight.any
+++ b/Body/AAUHuman/Trunk/PsoasMajorRight.any
@@ -6,7 +6,7 @@ Mark de Zee (23-04-2003)
 
 AnyFolder PsoasMajor = {
   
-  AnyVar StringMesh=15;
+  AnyIntVar StringMesh=15;
   
   AnyMuscleShortestPath PMT12I_TM = {
     AnyMuscleModel &MusMdl = ...MuscleParametersSpineRight.PsoasMajorParameter.PMT12I_TMPar;


### PR DESCRIPTION
AnyIntVar can be used for the old, upcoming and future StringMesh definition.
Old: AnyVar
Upcoming: AnyFloat
Future: AnyInt