### PR TITLE
Backport the SternalBody Segment reference

### DIFF
--- a/Body/AAUHuman/Trunk/Buckle.any
+++ b/Body/AAUHuman/Trunk/Buckle.any
@@ -33,7 +33,7 @@ AnyFolder Buckle={
   
   //References
   AnyFolder &PelvisRef=.SegmentsLumbar.PelvisSeg;
-  AnyFolder &ThoraxRef=.SegmentsRibCage.SternumSeg;
+  AnyFolder &ThoraxRef=.SegmentsRibCage.SternalBodySeg;
   
   AnyFolder Segments ={
     
@@ -44,7 +44,7 @@ AnyFolder Buckle={
       Mass=0.1;
       Jii={0.1,0.1,0.1};
       //Set the inital position to be the midpoint between the control point on pelvis and thorax
-      r0=0.5*(...SegmentsRibCage.SternumSeg.BuckleNodeTopCenter.sRel*...SegmentsRibCage.SternumSeg.Axes0'+...SegmentsRibCage.SternumSeg.r0+
+      r0=0.5*(...SegmentsRibCage.SternalBodySeg.BuckleNodeTopCenter.sRel*...SegmentsRibCage.SternalBodySeg.Axes0'+...SegmentsRibCage.SternalBodySeg.r0+
       ...SegmentsLumbar.PelvisSeg.BuckleNodeBottomCenter.sRel*...SegmentsLumbar.PelvisSeg.Axes0'+...SegmentsLumbar.PelvisSeg.r0);
       
       AnyFunTransform3D &Scale =...ScalingTrunk.Lumbar.ScaleFunction;
@@ -289,7 +289,7 @@ AnyFolder Buckle={
     
     AnyFolder &PelvisRef=..SegmentsLumbar.PelvisSeg;
     //AnyFolder &T12Ref=..SegmentsThorax.T12Seg;
-    AnyFolder &Sternum=..SegmentsRibCage.SternumSeg;
+    AnyFolder &Sternum=..SegmentsRibCage.SternalBodySeg;
     
     PelvisRef={
       //this the node where the force from the abdominal pressure is applied to

--- a/Body/AAUHuman/Trunk/NodesForThoracicMuscles.any
+++ b/Body/AAUHuman/Trunk/NodesForThoracicMuscles.any
@@ -405,7 +405,7 @@ SegmentsThorax.T12Seg = {
   AnyRefNode SPL2T1Via2Node = {sRel= .Scale(.StdPar.SPL2T1Via2Node_pos );};
 };
 
-SegmentsRibCage.SternumSeg = {
+SegmentsRibCage.SternalBodySeg = {
   // Rectus Abdominis Nodes
   AnyRefNode RACP_CO7_1_R = {sRel = .Scale(.StdPar.Right.RACP_CO7Node_1__pos);};
   AnyRefNode RACP_CO6_2_R = {sRel = .Scale(.StdPar.Right.RACP_CO6Node_2__pos);};

--- a/Body/AAUHuman/Trunk/RibCageMuscleNodes.any
+++ b/Body/AAUHuman/Trunk/RibCageMuscleNodes.any
@@ -3,6 +3,22 @@ SegmentsRibCage = {
     // ----------------------------------------------CS Nodes-----------------------------------------------
     AnyRefNode CS1NodeR                 ={ sRel =.Scale (.StdPar.Right.CS1Node_pos);};
     AnyRefNode CS2NodeR                 ={ sRel =.Scale (.StdPar.Right.CS2Node_pos);};
+    AnyRefNode CS1NodeL                 ={ sRel =.Scale (.StdPar.Left.CS1Node_pos);};
+    AnyRefNode CS2NodeL                 ={ sRel =.Scale (.StdPar.Left.CS2Node_pos);};
+    
+    //----------------------------------------------CC Nodes------------------------------------------------
+    AnyRefNode R1NodeR                 ={ sRel =.Scale (.StdPar.Right.R1Node_pos);};
+    AnyRefNode R2NodeR                 ={ sRel =.Scale (.StdPar.Right.R2Node_pos);};
+
+    AnyRefNode R1NodeL                 ={ sRel =.Scale (.StdPar.Left.R1Node_pos);};
+    AnyRefNode R2NodeL                 ={ sRel =.Scale (.StdPar.Left.R2Node_pos);};
+
+    AnyRefNode LumpedHyoidStC0NodeRIns = {sRel = .Scale(.StdPar.Right.LumpedHyoidStC0Ins_pos); AnyDrawNode n={ScaleXYZ={1,1,1}*0.00125;RGB={1,0,0};};};
+    AnyRefNode LumpedHyoidStC0NodeLIns = {sRel = .Scale(.StdPar.Left.LumpedHyoidStC0Ins_pos); AnyDrawNode n={ScaleXYZ={1,1,1}*0.00125;RGB={1,0,0};};};
+  };
+  
+    SternalBodySeg = {
+    // ----------------------------------------------CS Nodes-----------------------------------------------
     AnyRefNode CS3NodeR                 ={ sRel =.Scale (.StdPar.Right.CS3Node_pos);};
     AnyRefNode CS4NodeR                 ={ sRel =.Scale (.StdPar.Right.CS4Node_pos);};
     AnyRefNode CS5NodeR                 ={ sRel =.Scale (.StdPar.Right.CS5Node_pos);};
@@ -11,8 +27,6 @@ SegmentsRibCage = {
     AnyRefNode CS8NodeR                 ={ sRel =.Scale (.StdPar.Right.CS8Node_pos);};
     AnyRefNode CS9NodeR                 ={ sRel =.Scale (.StdPar.Right.CS9Node_pos);};
     AnyRefNode CS10NodeR                ={ sRel =.Scale (.StdPar.Right.CS10Node_pos);};
-    AnyRefNode CS1NodeL                 ={ sRel =.Scale (.StdPar.Left.CS1Node_pos);};
-    AnyRefNode CS2NodeL                 ={ sRel =.Scale (.StdPar.Left.CS2Node_pos);};
     AnyRefNode CS3NodeL                 ={ sRel =.Scale (.StdPar.Left.CS3Node_pos);};
     AnyRefNode CS4NodeL                 ={ sRel =.Scale (.StdPar.Left.CS4Node_pos);};
     AnyRefNode CS5NodeL                 ={ sRel =.Scale (.StdPar.Left.CS5Node_pos);};
@@ -23,8 +37,6 @@ SegmentsRibCage = {
     AnyRefNode CS10NodeL                ={ sRel =.Scale (.StdPar.Left.CS10Node_pos);};
     
     //----------------------------------------------CC Nodes------------------------------------------------
-    AnyRefNode R1NodeR                 ={ sRel =.Scale (.StdPar.Right.R1Node_pos);};
-    AnyRefNode R2NodeR                 ={ sRel =.Scale (.StdPar.Right.R2Node_pos);};
     AnyRefNode R3NodeR                 ={ sRel =.Scale (.StdPar.Right.R3Node_pos);};
     AnyRefNode R4NodeR                 ={ sRel =.Scale (.StdPar.Right.R4Node_pos);};
     AnyRefNode R5NodeR                 ={ sRel =.Scale (.StdPar.Right.R5Node_pos);};
@@ -34,8 +46,6 @@ SegmentsRibCage = {
     AnyRefNode R9NodeR                 ={ sRel =.Scale (.StdPar.Right.R9Node_pos);};
     AnyRefNode R10NodeR                ={ sRel =.Scale (.StdPar.Right.R10Node_pos);};
 
-    AnyRefNode R1NodeL                 ={ sRel =.Scale (.StdPar.Left.R1Node_pos);};
-    AnyRefNode R2NodeL                 ={ sRel =.Scale (.StdPar.Left.R2Node_pos);};
     AnyRefNode R3NodeL                 ={ sRel =.Scale (.StdPar.Left.R3Node_pos);};
     AnyRefNode R4NodeL                 ={ sRel =.Scale (.StdPar.Left.R4Node_pos);};
     AnyRefNode R5NodeL                 ={ sRel =.Scale (.StdPar.Left.R5Node_pos);};
@@ -46,8 +56,6 @@ SegmentsRibCage = {
     AnyRefNode R10NodeL                ={ sRel =.Scale (.StdPar.Left.R10Node_pos);};
 
     AnyRefNode RACP_CO6Node            = {sRel = .Scale(.StdPar.RACP_CO6Node_pos);};                 
-    AnyRefNode LumpedHyoidStC0NodeRIns = {sRel = .Scale(.StdPar.Right.LumpedHyoidStC0Ins_pos);};
-    AnyRefNode LumpedHyoidStC0NodeLIns = {sRel = .Scale(.StdPar.Left.LumpedHyoidStC0Ins_pos);};
     AnyRefNode TrThR2SNodeRIns         = {sRel = .Scale(.StdPar.Right.TrThR2SNode_pos);};
     AnyRefNode TrThR3SNodeRIns         = {sRel = .Scale(.StdPar.Right.TrThR3SNode_pos);};
     AnyRefNode TrThR4SNodeRIns         = {sRel = .Scale(.StdPar.Right.TrThR4SNode_pos);};

--- a/Body/AAUHuman/Trunk/TrunkModel.root.any
+++ b/Body/AAUHuman/Trunk/TrunkModel.root.any
@@ -93,6 +93,7 @@ AnyFolder  SegmentsRibCage = {};
 
 SegmentsRibCage = {
   AnyFolder &SternumSeg = .SegmentsThorax.ThoraxSeg;
+  AnyFolder &SternalBodySeg = .SegmentsThorax.ThoraxSeg;
   AnyFolder RibsRight = {};
   AnyFolder RibsLeft = {};
 };


### PR DESCRIPTION
The sternum is split into two segments in the upcoming thoracic model.

This backports that structure for the rigid thorax.  @Hamedshayestehpour  can you review it?

