### PR TITLE
fix squat model loading error

### DIFF
--- a/Application/Examples/Squat/Model/LeftArmDrivers.any
+++ b/Application/Examples/Squat/Model/LeftArmDrivers.any
@@ -13,7 +13,7 @@
     
     DriverPos = pi/180*{
       .JntPos.Left.SternoClavicularProtraction,
-      .JntPos.Left.SternoClavicularElevation,
+      .JntPos.Left.SternoClavicularElevation
     };
     
     DriverVel = pi/180*{


### PR DESCRIPTION
When disabling the shoulder rhythm there where a comma to much.