### PR TITLE
Mocap marker check

### DIFF
--- a/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
+++ b/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
@@ -1,3 +1,9 @@
+// Point to a python environment with ezc3d installed
+// Can be created with
+// >>> conda create -n c3d ezc3d numpy
+// This will not be necessary in 7.4 where ezc3d is included.
+#path ANYBODY_PATH_PYTHONHOME "c:/Users/mel/mambaforge/envs/c3d/"
+
 #include "../libdef.any"
 
 // Enter and edit Trial Specific Data in this file:
@@ -11,3 +17,5 @@
 
 // Include the AnyMoCap Framwork
 #include "<ANYMOCAP_MODEL>"
+
+

--- a/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
+++ b/Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any
@@ -1,6 +1,6 @@
 // Point to a python environment with ezc3d installed
 // Can be created with
-// >>> conda create -n c3d ezc3d numpy
+// >>> conda create -n c3d ezc3d numpy debugpy
 // This will not be necessary in 7.4 where ezc3d is included.
 #path ANYBODY_PATH_PYTHONHOME "c:/Users/mel/mambaforge/envs/c3d/"
 

--- a/Tools/AnyMocap/CheckAnyMocapConfiguration.any
+++ b/Tools/AnyMocap/CheckAnyMocapConfiguration.any
@@ -214,7 +214,34 @@ Macros =
     );
     #endif
 
+    #ifpathexists "c3d_marker_check.py"
+    AnyFunEx CheckC3D = {
+      Return = "";
+      AnyFunExMonoPy check_c3d_file = {
+         ModuleFile = "c3d_marker_check.py";
+         ArgList = {
+            AnyString c3dpath = "";
+         };
+      };
+    };
+    AnyString C3D_warning_str = CheckC3D(Main.ModelSetup.C3DFileData.FileName);
+    AnyInt C3D_warning = warn(not(bool(warning)), C3D_warning_str);    
+    #endif
+
   };
     
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
     
 };

--- a/Tools/AnyMocap/CheckAnyMocapConfiguration.any
+++ b/Tools/AnyMocap/CheckAnyMocapConfiguration.any
@@ -214,6 +214,7 @@ Macros =
     );
     #endif
 
+    #if MOCAP_INPUT_DATA_TYPE == "C3D"
     #ifndef MOCAP_DISABLE_C3D_MARKER_CHECK
     #ifpathexists "c3d_marker_check.py"
     
@@ -237,6 +238,7 @@ Macros =
           strformat("\n\n C3D marker checks can be disabled with #define MOCAP_DISABLE_C3D_MARKER_CHECK \n")+
           strformat("------------------------------------------------------------------------------------------------------------------------------\n") ;
     };
+    #endif
     #endif
     #endif
 

--- a/Tools/AnyMocap/CheckAnyMocapConfiguration.any
+++ b/Tools/AnyMocap/CheckAnyMocapConfiguration.any
@@ -214,18 +214,30 @@ Macros =
     );
     #endif
 
+    #ifndef MOCAP_DISABLE_C3D_MARKER_CHECK
     #ifpathexists "c3d_marker_check.py"
-    AnyFunEx CheckC3D = {
-      Return = "";
-      AnyFunExMonoPy check_c3d_file = {
-         ModuleFile = "c3d_marker_check.py";
-         ArgList = {
-            AnyString c3dpath = "";
+    
+    AnyMessage C3D_Marker_Check = {
+       
+       AnyFunEx CheckC3D = {
+         AnyStringVar Return = "";
+         AnyFunExMonoPy check_c3d_file = {
+            ModuleFile = "c3d_marker_check.py";
+            ArgList = {
+               AnyString c3dpath = "";
+            };
          };
-      };
+       };
+      
+      AnyString C3D_warning_str = CheckC3D(FilePathCompleteOf(Main.ModelSetup.C3DFileData.FileName));
+      TriggerConst = bool(C3D_warning_str);
+      Type=MSG_Warning;
+       Message = strformat("\n------------------------------------------------------------------------------------------------------------------------------\n")+
+          C3D_warning_str +
+          strformat("\n\n C3D marker checks can be disabled with #define MOCAP_DISABLE_C3D_MARKER_CHECK \n")+
+          strformat("------------------------------------------------------------------------------------------------------------------------------\n") ;
     };
-    AnyString C3D_warning_str = CheckC3D(Main.ModelSetup.C3DFileData.FileName);
-    AnyInt C3D_warning = warn(not(bool(warning)), C3D_warning_str);    
+    #endif
     #endif
 
   };

--- a/Tools/AnyMocap/c3d_marker_check.py
+++ b/Tools/AnyMocap/c3d_marker_check.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+from textwrap import fill
+from typing import NamedTuple
+
+import ezc3d 
+
+import functools
+
+
+class Context(NamedTuple):
+    py_file: str
+    fun_name: str
+    anyfun_full_name: str
+    anyfunex_file: str
+    anyfunex_line: str
+    call_location_file:str
+
+
+
+def check_c3d_file(context: Context, c3d_file: str):
+    """ Check if fpath is a writeable file """
+    
+    report_str = "" 
+
+    if not os.path.isfile(c3d_file):
+        return f"{c3d_file} is not a file\n"
+
+    c3d = ezc3d.c3d(c3d_file)
+    points_used = c3d['parameters']['POINT']['USED']['value'][0];  # Print the number of points used
+    point_data = c3d['data']['points']
+
+    report_str += f"Points used: {points_used}\n"
+    report_str += f"Points data: \n{point_data}\n"
+    
+    return report_str
+
+
+
+
+if __name__ == "__main__":
+   check_c3d_file("test.c3d")

--- a/Tools/AnyMocap/c3d_marker_check.py
+++ b/Tools/AnyMocap/c3d_marker_check.py
@@ -21,17 +21,19 @@ class Context(NamedTuple):
 def check_c3d_file(context: Context, c3d_file: str):
     """ Check if fpath is a writeable file """
     
-    report_str = "" 
+    report_str = ( 
+        "This is an example of analyzing a c3d file.\n" + 
+        "If nothing is returned from python the warning will not be triggered.\n"
+    )
 
     if not os.path.isfile(c3d_file):
-        return f"{c3d_file} is not a file\n"
+        return f"{c3d_file} is not a file\n\n"
 
     c3d = ezc3d.c3d(c3d_file)
     points_used = c3d['parameters']['POINT']['USED']['value'][0];  # Print the number of points used
     point_data = c3d['data']['points']
 
-    report_str += f"Points used: {points_used}\n"
-    report_str += f"Points data: \n{point_data}\n"
+    report_str += f"Number of Points in c3d file: {points_used}\n"
     
     return report_str
 


### PR DESCRIPTION
This is prof-of-concept on how to use a python hook in a MoCap model analyse a c3d file and print the result of the analysis directly in the AnyBody output window. 

To use the example: 

1. Open the file: 
    Application/MocapExamples/Plug-in-gait_Simple/LowerExtremity.main.any

2. Then change the `#path ANYBODY_PATH_PYTHONHOME` variable to point to a local 
   python environment with `ezc3d` installed (e.g. conda install -c conda-forge ez3d"
   > This step will not be necessary in 7.4 as this will come with ezc3d in the builtin python distribution. 

3. Load the model


The check is done in the file: 
Tools/AnyMocap/c3d_marker_check.py


It is currently hard to debug python when running through a hook. I suggest running the python file directly when testing. 