### PR TITLE
Fix typo in define statement

### DIFF
--- a/Tests/AnyMocap/Test_ExternalDesVar.any
+++ b/Tests/AnyMocap/Test_ExternalDesVar.any
@@ -10,7 +10,7 @@
 
 
 #ifndef BM_LEG_MODEL
-#define BM_LEG_MODEL_LEG_MODEL_TLEM2_
+#define BM_LEG_MODEL _LEG_MODEL_TLEM2_
 #endif
 
 


### PR DESCRIPTION
The test seemed to work since `BM_LEG_MODEL` defaults to `_LEG_MODEL_TLEM2_`