### PR TITLE
Adjust the range of motion for trunk evaluate joint strength

### DIFF
--- a/Body/AAUHuman/Trunk/EvaluateJointStrengthSequence.any
+++ b/Body/AAUHuman/Trunk/EvaluateJointStrengthSequence.any
@@ -4,7 +4,7 @@
    AnyFolder PelvisThoraxFlexion ={
       
       // Change the following variables to adjust the moment arm study
-      AnyVector RangeOfMotion = DesignVar({30,-45});
+      AnyVector RangeOfMotion = DesignVar({34,-45});
       AnyVar PelvisThoraxLateralBending= DesignVar(0);
       AnyVar PelvisThoraxRotation= DesignVar(0);
       /////////////////////////////////////////


### PR DESCRIPTION
This particular model seems to be very unstable, with the current buckle implementation. 

The change in joint range of motion for the "evaluate joint strength", improves it a bit. This is really a temporary workaround, until the new abdominal model comes out. 