### PR TITLE
Fix a problem with CreateVideo visibility in operation menu

### DIFF
--- a/Application/MocapExamples/ADL_Gait_[beta]/CreateVideo.any
+++ b/Application/MocapExamples/ADL_Gait_[beta]/CreateVideo.any
@@ -49,7 +49,10 @@ VIDEO_STUDY = {
 };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
  
  

--- a/Application/MocapExamples/BVH_BoxLift/Model/CreateVideo.any
+++ b/Application/MocapExamples/BVH_BoxLift/Model/CreateVideo.any
@@ -48,7 +48,10 @@ VideoLookAtCamera VideoTool (UP_DIRECTION = y) =
  };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
  
  

--- a/Application/MocapExamples/BVH_Xsens/CreateVideo.any
+++ b/Application/MocapExamples/BVH_Xsens/CreateVideo.any
@@ -50,8 +50,13 @@ VideoLookAtCamera VideoTool (UP_DIRECTION = y) =
 };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
+ 
+ 
  
  
  

--- a/Application/MocapExamples/BVH_Xsens_OptimizeOrigin/CreateVideo.any
+++ b/Application/MocapExamples/BVH_Xsens_OptimizeOrigin/CreateVideo.any
@@ -44,11 +44,16 @@ VideoLookAtCamera VideoTool (UP_DIRECTION = y) =
      Analysis = {
          AnyOperation &ref = VIDEO_STUDY.VIDEO_ANALYSIS;
      };
+
+     Create_Video.Settings.DisplayPriority = PriorityLow;
  };
 };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
  
  

--- a/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/CreateVideo.any
+++ b/Application/MocapExamples/Plug-in-gait_MultiTrial_StandingRef/CreateVideo.any
@@ -53,11 +53,16 @@ VIDEO_STUDY = {
      Analysis = {
          AnyOperation &ref = VIDEO_STUDY.VIDEO_ANALYSIS;
      };
+
+     Create_Video.Settings.DisplayPriority = PriorityLow;
  };
 };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
  
  

--- a/Application/MocapExamples/Plug-in-gait_Simple/Setup/CreateVideo.any
+++ b/Application/MocapExamples/Plug-in-gait_Simple/Setup/CreateVideo.any
@@ -68,7 +68,10 @@ VIDEO_STUDY = {
 };
  
  Main.ModelSetup = {
-   AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   AnyOperationSequence CreateVideo = {
+     Settings.DisplayPriority = PriorityHigh;
+     AnyOperation& CreateVideo = VIDEO_STUDY.VideoTool.Create_Video;
+   };
  };
  
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 % To minimize the risk of merge conflicts insert the your changes at a
 % random empty or make a new entry a random place in the bullet lists.
 
-## AMMR beta 
+## AMMR beta
+
+**Fixed:**
+* The `Main.ModelSetup.CreateVideo` operation was missing in some of the
+  MoCap examples. This has been fixed. If you have this problem update the `CreateVideo.any` file in your application. 
 
 **Added:**
 


### PR DESCRIPTION
The CreateVideo operation was not visible in some the MoCap examples.
This i has been fixed, but it requires that users update their
applications with the new `CreateVideo.any` file from the examples.