### PR TITLE
Fix worng marker name

### DIFF
--- a/Application/MocapExamples/ADL_Gait_[beta]/MarkerProtocol.any
+++ b/Application/MocapExamples/ADL_Gait_[beta]/MarkerProtocol.any
@@ -593,7 +593,7 @@ UseC3DWeightResiduals = ON
 
 #ifdef _R_UHE
 // Marker on the Right Wrist B
-CreateMarkerDriver R_UHERSP (
+CreateMarkerDriver R_UHE (
 MarkerPlacement=Right.ShoulderArm.Seg.Hand, 
 OptX=ON,OptY=ON,OptZ=ON,
 UseC3DWeightResiduals = ON 
@@ -689,7 +689,7 @@ UseC3DWeightResiduals = ON
 
 #ifdef _L_UHE
 // Marker on the Left Wrist B
-CreateMarkerDriver L_UHERSP (
+CreateMarkerDriver L_UHE (
 MarkerPlacement=Left.ShoulderArm.Seg.Hand, 
 OptX=ON,OptY=ON,OptZ=ON,
 UseC3DWeightResiduals = ON 


### PR DESCRIPTION
The marker driver name is now used to lookup the marker.
So the name must be correct.  This fixes a test regression.

No changelog entry is needed for this fix.