### PR TITLE
Update load-time position of the box according to the hands. 

### DIFF
--- a/Application/MocapExamples/BVH_BoxLift/Model/box.any
+++ b/Application/MocapExamples/BVH_BoxLift/Model/box.any
@@ -1,7 +1,7 @@
 Main.ModelSetup ={
   /// Various EnvironmentParameters for adjusting the Box
   AnyFolder EnvironmentParameters = {
-    AnyInt GravityDirection  = 1 ; // y
+    AnyInt GravityDirection  = iffun(Main.ModelSetup.LabSpecificData.Gravity[0],0,iffun(Main.ModelSetup.LabSpecificData.Gravity[1],1,2)); // 0 if x, 1 if y, 2 if z
     AnyVar BoxWeight = 10; // kg
     AnyVec3 BoxJii= {0.1,0.1,0.1}; // Inertia
     AnyVec3 BoxDimensions ={0.36,0.40,0.53}; // m (length, height, width)
@@ -15,6 +15,13 @@ Main.ModelSetup ={
 AnySeg Box ={
   Mass= Main.ModelSetup.EnvironmentParameters.BoxWeight;
   Jii= Main.ModelSetup.EnvironmentParameters.BoxJii;
+  
+  // Position and orient the box according to the hands
+  r0 = (Main.HumanModel.BodyModel.Right.ShoulderArm.Seg.Hand.r0 +Main.HumanModel.BodyModel.Left.ShoulderArm.Seg.Hand.r0)/2 -
+       (Main.ModelSetup.EnvironmentParameters.RightHandle + Main.ModelSetup.EnvironmentParameters.LeftHandle)/2*Axes0';
+  Axes0 = RotMat(Main.HumanModel.BodyModel.Left.ShoulderArm.Seg.Hand.r0, 
+                 Main.HumanModel.BodyModel.Right.ShoulderArm.Seg.Hand.r0, 
+                 Main.HumanModel.BodyModel.Left.ShoulderArm.Seg.Hand.r0 - Main.ModelSetup.LabSpecificData.Gravity)*RotMat(pi/2,y);
   
   AnyFunTransform3DLin GeomScale = {
     ScaleMat ={{1,0,0},{0,1,0},{0,0,1}};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   ```
 
 **Changed:**
+* The load-time position of the box in the {ref}`BVH_BoxLift model <sphx_glr_auto_examples_Mocap_plot_BVH_BoxLift.py>` is now 
+  calculated using the position of the hands. Also, `Main.ModelSetup.EnvironmentParameters.GravityDirection` defined in `box.any` file
+  is now calculated automatically from `Main.ModelSetup.LabSpecificData.Gravity` defined in `LabSpecificData.any` file. These changes should 
+  make the model more robust when dealing with different bvh files.
 * It is no longer necessasry to supply the `MarkerName` argument in the CreateMarkerDriver template
   MoCap models. The argument can still be used if the marker name and the data entry in the c3d file 
   are different. 


### PR DESCRIPTION
This patch updates the load-time position of the box in the BVH box lift model. The load time position and orientation are calculated according to the hands. 

Also, the GravityDirection parameter defined in box.any is calculated automatically from the Gravity vector defined in LabSpecificData.any.

The pull request also includes changelog entry.