### PR TITLE
Remove unused guard in tests

### DIFF
--- a/Tests/AnyMocap/Test_ADL_Gait.any
+++ b/Tests/AnyMocap/Test_ADL_Gait.any
@@ -6,9 +6,6 @@
 //  "Main.Studies.MarkerTracking",
 //  "Main.Studies.InverseDynamicStudy",
 //]
-//if "7.4_Beta" in pytest.anytest.ams_path:
-//   # 'Update values' causes extra warnings in 7.4_Beta
-//   ignore_errors.extend(['PML5_TM.SPLine', 'Extensor_Digitorum__Digit3.SPLine'])
 
 
 


### PR DESCRIPTION
This issue in [AB#1646](https://abtv-devops1/AnyBodyTech/be71f005-c830-46ca-9fb5-c92f0c92d6c0/_workitems/edit/1646) was fixed. This removes the temporary guards, which were added to the test system