### PR TITLE
Option for viewing camera in video exporter CT

### DIFF
--- a/Tools/ModelUtilities/Video/CameraClassTemplate.any
+++ b/Tools/ModelUtilities/Video/CameraClassTemplate.any
@@ -124,7 +124,7 @@ Main = {
   /// The distance from the camera to the scene. This does NOT determine the 
   /// size of scene, since Perspective is off by default. To zoom in/out, use 
   /// CameraFeildOfView. 
-  #var AnyVar CameraDistance = DesignVar(10);
+  #var AnyVar CameraDistance = DesignVar(6);
   
   /// The vertical field of view in meters at the LookAtPoint
   #var AnyVar CameraFieldOfView = DesignVar(2);
@@ -153,8 +153,9 @@ Main = {
   
   /// Video output framerate. 
   #var AnyIntVar GifOutputFrameRate = VideoOutputFrameRate;
-
   
+  /// Switch to view camera eye point.
+  #var AnySwitchVar viewCamera = Off; 
   
   
   /// Operation to show a preview of what the camera sees. 
@@ -226,6 +227,8 @@ Main = {
   
   
   AnyCameraLookAt Camera = {
+    
+    AnyDrawCamera drawcam = {Visible = ..viewCamera;};
     
     #var Perspective = DesignVar(Off);
     #var EyePoint = .CameraLookAtPoint + .CameraDistance *.CameraDirection;


### PR DESCRIPTION
This pull request adds an option to view the camera in the video exporter class template (Defaults to off)

Also, the default camera distance is reduced to 6 from 10.

No changelog is required. 
