### PR TITLE
Add AMS 7.5 case for ObjRefResolve

### DIFF
--- a/Body/AAUHuman/Arm/Calibration/SpineDependentCal.any
+++ b/Body/AAUHuman/Arm/Calibration/SpineDependentCal.any
@@ -297,7 +297,12 @@ AnyBodyCalibrationStudy ArmCalibrationStudySpineDependent = {
   InitialConditions.PosAnalysisOnlyOnOff = On;
   
   // Warning once cleidomastoid becomes a 3 element muscle
+  #if (ANYBODY_V1 > 7) | ( ANYBODY_V1 == 7 & ANYBODY_V2 >= 5)
+  AnyStringVar cleidomastoid_type = ClassNameOf(ObjRefResolve(&.SideHumanFolderRef.ShoulderArm.Mus.Sternocleidomastoid_caput_clavicular.MusMdl));
+  #else
   AnyStringVar cleidomastoid_type = ClassNameOf(&.SideHumanFolderRef.ShoulderArm.Mus.Sternocleidomastoid_caput_clavicular.MusMdl);
+  #endif
+  
   AnyVar expect_no_cleidomastoid_calibration = expect(
         eqfun(cleidomastoid_type, "AnyMuscleModel"),
         "SternocleidomastoidMuscles must be added to the calibration study"


### PR DESCRIPTION
This small fix is  necessary as 7.5 changed the default behavior `ClassNameOf()`. References are no longer resolved automatically. 