### PR TITLE
Backport: Adjust psoas via points and origins (#731)

### DIFF
--- a/Body/AAUHuman/Trunk/TrunkData1.1/LumbarNodes.any
+++ b/Body/AAUHuman/Trunk/TrunkData1.1/LumbarNodes.any
@@ -153,17 +153,17 @@ AnyFolder Pelvis = {
     AnyVec3 IliopubicEminenceViaNode_pos = {0.086, -0.102, 0.078};
     AnyFloat IliopubicEminenceEndNode_pos = {0.089,-0.1101,0.0785}; 
 
-    AnyFloat PMT12I_TMVia5Node_pos = {0.080, -0.037, (..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ * (..Thorax.Right.PMT12I_TMNode_pos[1] + 0.037))};
-    AnyFloat PML1I_TMVia4Node_pos  = {0.080, -0.037, (..L1.Right.PML1I_TMNode_pos[2] - ..L3.PML1I_TMZ * (..L1.Right.PML1I_TMNode_pos[1] + 0.037))};
-    AnyFloat PML2I_TMVia3Node_pos  = {0.080, -0.037, (..L2.Right.PML2I_TMNode_pos[2] - ..L3.PML2I_TMZ * (..L2.Right.PML2I_TMNode_pos[1] + 0.037))};
-    AnyFloat PML3I_TMVia2Node_pos  = {0.080, -0.037, (..L3.Right.PML3I_TMNode_pos[2] - ..L3.PML3I_TMZ * (..L3.Right.PML3I_TMNode_pos[1] + 0.037))};
-    AnyFloat PML4I_TMVia1Node_pos  = {0.080, -0.037, (..L4.Right.PML4I_TMNode_pos[2] - ..L3.PML4I_TMZ * (..L4.Right.PML4I_TMNode_pos[1] + 0.037))};
-    AnyFloat PML5_TMVia1Node_pos   = {0.080, -0.037, (..L5.Right.PML5_TMNode_pos[2] - ..L3.PML5_TMZ  * (..L5.Right.PML5_TMNode_pos[1] + 0.037))};
-    AnyFloat PML1T_TMVia5Node_pos  = {0.0585, -0.045, (..L1.Right.PML1T_TMNode_pos[2] - ..L2.PML1T_TMZ*(..L1.Right.PML1T_TMNode_pos[1] + 0.037))};
-    AnyFloat PML2T_TMVia4Node_pos  = {0.0585, -0.045, (..L2.Right.PML2T_TMNode_pos[2] - ..L2.PML2T_TMZ*(..L2.Right.PML2T_TMNode_pos[1] + 0.037))};
-    AnyFloat PML3T_TMVia3Node_pos  = {0.0585, -0.045, (..L3.Right.PML3T_TMNode_pos[2] - ..L2.PML3T_TMZ*(..L3.Right.PML3T_TMNode_pos[1] + 0.037))};
-    AnyFloat PML4T_TMVia2Node_pos  = {0.0585, -0.045, (..L4.Right.PML4T_TMNode_pos[2] - ..L2.PML4T_TMZ*(..L4.Right.PML4T_TMNode_pos[1] + 0.037))};
-    AnyFloat PML5T_TMVia1Node_pos  = {0.0585, -0.045, (..L5.Right.PML5T_TMNode_pos[2] - ..L2.PML5T_TMZ*(..L5.Right.PML5T_TMNode_pos[1] + 0.037))};
+    AnyFloat PMT12I_TMVia5Node_pos = {0.074, -0.037, (..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ * (..Thorax.Right.PMT12I_TMNode_pos[1] + 0.037))};
+    AnyFloat PML1I_TMVia4Node_pos  = {0.072, -0.037, (..L1.Right.PML1I_TMNode_pos[2] - ..L3.PML1I_TMZ * (..L1.Right.PML1I_TMNode_pos[1] + 0.037))};
+    AnyFloat PML2I_TMVia3Node_pos  = {0.070, -0.037, (..L2.Right.PML2I_TMNode_pos[2] - ..L3.PML2I_TMZ * (..L2.Right.PML2I_TMNode_pos[1] + 0.037))};
+    AnyFloat PML3I_TMVia2Node_pos  = {0.068, -0.037, (..L3.Right.PML3I_TMNode_pos[2] - ..L3.PML3I_TMZ * (..L3.Right.PML3I_TMNode_pos[1] + 0.037))};
+    AnyFloat PML4I_TMVia1Node_pos  = {0.066, -0.037, (..L4.Right.PML4I_TMNode_pos[2] - ..L3.PML4I_TMZ * (..L4.Right.PML4I_TMNode_pos[1] + 0.037))};
+    AnyFloat PML5_TMVia1Node_pos   = {0.064, -0.037, (..L5.Right.PML5_TMNode_pos[2] - ..L3.PML5_TMZ  * (..L5.Right.PML5_TMNode_pos[1] + 0.037))};
+    AnyFloat PML1T_TMVia5Node_pos  = {0.0585, -0.048, (..L1.Right.PML1T_TMNode_pos[2] - ..L2.PML1T_TMZ*(..L1.Right.PML1T_TMNode_pos[1] + 0.037))};
+    AnyFloat PML2T_TMVia4Node_pos  = {0.0585, -0.048, (..L2.Right.PML2T_TMNode_pos[2] - ..L2.PML2T_TMZ*(..L2.Right.PML2T_TMNode_pos[1] + 0.037))};
+    AnyFloat PML3T_TMVia3Node_pos  = {0.0585, -0.048, (..L3.Right.PML3T_TMNode_pos[2] - ..L2.PML3T_TMZ*(..L3.Right.PML3T_TMNode_pos[1] + 0.037))};
+    AnyFloat PML4T_TMVia2Node_pos  = {0.0585, -0.048, (..L4.Right.PML4T_TMNode_pos[2] - ..L2.PML4T_TMZ*(..L4.Right.PML4T_TMNode_pos[1] + 0.037))};
+    AnyFloat PML5T_TMVia1Node_pos  = {0.0585, -0.048, (..L5.Right.PML5T_TMNode_pos[2] - ..L2.PML5T_TMZ*(..L5.Right.PML5T_TMNode_pos[1] + 0.037))};
 
     AnyFloat QLNode_pos = {0.053000, 0.05400000,  0.08300000} - {0.015,0.0075,0};
     AnyFloat RA_Node1_pos = {0.115000, -0.1310000,   0.00000000};
@@ -349,8 +349,7 @@ AnyFolder L5 = {
     AnyFloat LTptT12SacrumVia5Node_pos = {-0.001-0.015,0.011,(..Thorax.Right.LTptT12SacrumNode_pos[2] - ..Thorax.LTptT12SacrumZ*(..Thorax.Right.LTptT12SacrumNode_pos[1] - 0.011))};
     
     // Psoas Major Nodes
-    AnyVar  PML5_Translate =0.015;
-    AnyVec3 PML5_TMNodeR0 = { PML5_Translate+0.049,0.011,0.021};
+    AnyVec3 PML5_TMNodeR0 = { 0.064,0.011,0.021};
     AnyVec3 PML5T_TMNodeR0 = {0.034,0.020,0.028};
     
 	// End of Psoas Major Nodes
@@ -366,16 +365,16 @@ AnyFolder L5 = {
     AnyFloat MFL5T12Node_pos = {0.02500000, 0.02200000, 0.02400000};
     AnyFloat L5ContactNode_pos = {-0.01000000, 0.008000000, 0.05000000};
 
-    AnyVec3 PML5_TMNode_pos = { PML5_Translate+0.049,0.011,0.021};
+    AnyVec3 PML5_TMNode_pos = { 0.066, 0.011, 0.021};
     AnyVec3 PML5T_TMNode_pos = {0.034,0.020,0.028};
-    AnyFloat PMT12I_TMVia4Node_pos = {0.070                         ,0.008,(..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ*(..Thorax.Right.PMT12I_TMNode_pos[1] - 0.008))};
-    AnyFloat PML1I_TMVia3Node_pos  = {0.070                         ,0.008,(..L1.Right.PML1I_TMNode_pos[2]      - ..L3.PML1I_TMZ*(..L1.Right.PML1I_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML2I_TMVia2Node_pos  = {0.070                         ,0.008,(..L2.Right.PML2I_TMNode_pos[2]      - ..L3.PML2I_TMZ*(..L2.Right.PML2I_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML3I_TMVia1Node_pos  = {0.070                         ,0.008,(..L3.Right.PML3I_TMNode_pos[2]      - ..L3.PML3I_TMZ*(..L3.Right.PML3I_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML1T_TMVia4Node_pos  = {0.039                         ,0.008,(..L1.Right.PML1T_TMNode_pos[2]      - ..L2.PML1T_TMZ*(..L1.Right.PML1T_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML2T_TMVia3Node_pos  = {0.039                         ,0.008,(..L2.Right.PML2T_TMNode_pos[2]      - ..L2.PML2T_TMZ*(..L2.Right.PML2T_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML3T_TMVia2Node_pos  = {0.039                         ,0.008,(..L3.Right.PML3T_TMNode_pos[2]      - ..L2.PML3T_TMZ*(..L3.Right.PML3T_TMNode_pos[1]           - 0.008))};
-    AnyFloat PML4T_TMVia1Node_pos  = {0.039                         ,0.008,(..L4.Right.PML4T_TMNode_pos[2]      - ..L2.PML4T_TMZ*(..L4.Right.PML4T_TMNode_pos[1]           - 0.008))};
+    AnyFloat PMT12I_TMVia4Node_pos = {0.067                         ,0.008,(..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ*(..Thorax.Right.PMT12I_TMNode_pos[1] - 0.008))};
+    AnyFloat PML1I_TMVia3Node_pos  = {0.067                         ,0.008,(..L1.Right.PML1I_TMNode_pos[2]      - ..L3.PML1I_TMZ*(..L1.Right.PML1I_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML2I_TMVia2Node_pos  = {0.067                         ,0.008,(..L2.Right.PML2I_TMNode_pos[2]      - ..L3.PML2I_TMZ*(..L2.Right.PML2I_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML3I_TMVia1Node_pos  = {0.067                         ,0.008,(..L3.Right.PML3I_TMNode_pos[2]      - ..L3.PML3I_TMZ*(..L3.Right.PML3I_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML1T_TMVia4Node_pos  = {0.041                         ,-0.005,(..L1.Right.PML1T_TMNode_pos[2]      - ..L2.PML1T_TMZ*(..L1.Right.PML1T_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML2T_TMVia3Node_pos  = {0.041                         ,-0.005,(..L2.Right.PML2T_TMNode_pos[2]      - ..L2.PML2T_TMZ*(..L2.Right.PML2T_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML3T_TMVia2Node_pos  = {0.041                         ,-0.005,(..L3.Right.PML3T_TMNode_pos[2]      - ..L2.PML3T_TMZ*(..L3.Right.PML3T_TMNode_pos[1]           - 0.008))};
+    AnyFloat PML4T_TMVia1Node_pos  = {0.041                         ,-0.005,(..L4.Right.PML4T_TMNode_pos[2]      - ..L2.PML4T_TMZ*(..L4.Right.PML4T_TMNode_pos[1]           - 0.008))};
   };
 
   AnyFolder Left = {
@@ -451,7 +450,7 @@ AnyFolder L4 = {
     AnyFloat LTptT12SacrumVia4Node_pos = {.LSNode_pos[0]      -0.005,.LSNode_pos[1],(..Thorax.Right.LTptT12SacrumNode_pos[2] - ..Thorax.LTptT12SacrumZ*(..Thorax.Right.LTptT12SacrumNode_pos[1] - .LSNode_pos[1]))};
 
     // Psoas Major Nodes
-    AnyVec3 PML4I_TMNode_pos = {0.015 + 0.052,0.023,0.022};
+    AnyVec3 PML4I_TMNode_pos = {0.069, 0.033, 0.022};
     AnyVec3 PML4T_TMNode_pos = {0.034,0.050,0.028};
     AnyFloat PMT12I_TMVia3Node_pos = {0.069                          ,0.043,(..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ*(..Thorax.Right.PMT12I_TMNode_pos[1] - 0.043))};
     AnyFloat PML1I_TMVia2Node_pos  = {0.069                          ,0.043,(..L1.Right.PML1I_TMNode_pos[2]      - ..L3.PML1I_TMZ     *(..L1.Right.PML1I_TMNode_pos[1]      - 0.043))}; 
@@ -525,7 +524,6 @@ AnyFolder L3 = {
   AnyVar ILplL2CIZ = (.L2.Right.ILplL2CINode_pos[2]-.Pelvis.Right.ILplL2CINode_pos[2])/(.L2.Right.ILplL2CINode_pos[1]-.Pelvis.Right.ILplL2CINode_pos[1]);
   AnyVar LTplL1SIPSZ = (.L1.Right.LTplL1SIPSNode_pos[2]-.Pelvis.Right.LTplL1SIPSNode_pos[2])/(.L1.Right.LTplL1SIPSNode_pos[1]-.Pelvis.Right.LTplL1SIPSNode_pos[1]);
   AnyVar LTplL2SIPSZ = (.L2.Right.LTplL2SIPSNode_pos[2]-.Pelvis.Right.LTplL2SIPSNode_pos[2])/(.L2.Right.LTplL2SIPSNode_pos[1]-.Pelvis.Right.LTplL2SIPSNode_pos[1]);
-  AnyVar     PML3I_Translation=0.015;
   AnyVar PML1I_TMZ = (.L1.Right.PML1I_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L1.Right.PML1I_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
   AnyVar PML2I_TMZ = (.L2.Right.PML2I_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L2.Right.PML2I_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
   AnyVar PML3I_TMZ = (.L3.Right.PML3I_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L3.Right.PML3I_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
@@ -562,7 +560,7 @@ AnyFolder L3 = {
     AnyFloat LTptT10SacrumVia5Node_pos = {.LSNode_pos[0]      ,.LSNode_pos[1],(..Thorax.Right.LTptT10SacrumNode_pos[2] - ..Thorax.LTptT10SacrumZ*(..Thorax.Right.LTptT10SacrumNode_pos[1] - .LSNode_pos[1]))};
     AnyFloat LTptT11SacrumVia4Node_pos = {.LSNode_pos[0]      ,.LSNode_pos[1],(..Thorax.Right.LTptT11SacrumNode_pos[2] - ..Thorax.LTptT11SacrumZ*(..Thorax.Right.LTptT11SacrumNode_pos[1] - .LSNode_pos[1]))};
     AnyFloat LTptT12SacrumVia3Node_pos = {.LSNode_pos[0]      ,.LSNode_pos[1],(..Thorax.Right.LTptT12SacrumNode_pos[2] - ..Thorax.LTptT12SacrumZ*(..Thorax.Right.LTptT12SacrumNode_pos[1] - .LSNode_pos[1]))};
-    AnyVec3 PML3I_TMNode_pos = {.PML3I_Translation+0.051,0.061,0.022};
+    AnyVec3 PML3I_TMNode_pos = {0.068, 0.071, 0.022};
     AnyVec3 PML3T_TMNode_pos = {0.030,0.079,0.028};
     AnyFloat PMT12I_TMVia2Node_pos = {0.065,0.079,(..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ*(..Thorax.Right.PMT12I_TMNode_pos[1] - 0.079))};
     AnyFloat PML1I_TMVia1Node_pos  = {0.065,0.079,(..L1.Right.PML1I_TMNode_pos[2] -        .PML1I_TMZ          *(..L1.Right.PML1I_TMNode_pos[1]      - 0.079))};
@@ -647,7 +645,6 @@ AnyFolder L2 = {
   AnyFloat LINodeSuperior_pos = {0.009000000, 0.1000000, 0.0000000};
   AnyVar ILplL1CIZ = (.L1.Right.ILplL1CINode_pos[2]-.Pelvis.Right.ILplL1CINode_pos[2])/(.L1.Right.ILplL1CINode_pos[1]-.Pelvis.Right.ILplL1CINode_pos[1]);
   AnyVar LTplL1SIPSZ = (.L1.Right.LTplL1SIPSNode_pos[2]-.Pelvis.Right.LTplL1SIPSNode_pos[2])/(.L1.Right.LTplL1SIPSNode_pos[1]-.Pelvis.Right.LTplL1SIPSNode_pos[1]);
-  AnyVar PML2I_Translation=0.015;
   AnyVar PML1T_TMZ = (.L1.Right.PML1T_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L1.Right.PML1T_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
   AnyVar PML2T_TMZ = (.L2.Right.PML2T_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L2.Right.PML2T_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
   AnyVar PML3T_TMZ = (.L3.Right.PML3T_TMNode_pos[2]-.Pelvis.Right.IliopubicEminenceViaNode_pos[2])/(.L3.Right.PML3T_TMNode_pos[1]-.Pelvis.Right.IliopubicEminenceViaNode_pos[1]);
@@ -689,10 +686,10 @@ AnyFolder L2 = {
     AnyVec3 ILplL2CINode_pos = {0.013,0.104,0.034};
     AnyVec3 LTplL2SIPSNode_pos = {0.015,0.105,0.027};
     AnyVec3 LTptT2L2Node_pos = {-0.005,0.082,0.0}; 
-    AnyVec3 PML2I_TMNode_pos = {0.045,0.094,0.022}+{.PML2I_Translation,0,0};
+    AnyVec3 PML2I_TMNode_pos = {0.06, 0.104, 0.022};
     AnyVec3 PML2T_TMNode_pos = {0.024,0.106,0.025};
     AnyFloat PMT12I_TMVia1Node_pos = {0.060,0.110,(..Thorax.Right.PMT12I_TMNode_pos[2] - ..Thorax.PMT12I_TMZ*(..Thorax.Right.PMT12I_TMNode_pos[1] - 0.110))};
-    AnyFloat PML1T_TMVia1Node_pos  = {0.031,0.105,(..L1.Right.PML1T_TMNode_pos[2]      - ..L2.PML1T_TMZ     *(..L1.Right.PML1T_TMNode_pos[1]      - 0.105))};
+    AnyFloat PML1T_TMVia1Node_pos  = {0.026,0.105,(..L1.Right.PML1T_TMNode_pos[2]      - ..L2.PML1T_TMZ     *(..L1.Right.PML1T_TMNode_pos[1]      - 0.105))};
     AnyFloat QLL2_CINode_pos = {0.01900000, 0.1050000, 0.03200000};
     AnyFloat OEC7_RSNode_pos = {0.1580000, 0.09800000, 0.01500000};
     AnyFloat OICI_RS1Node_pos = {0.1580000, 0.09800000, 0.01500000};
@@ -807,7 +804,7 @@ AnyFolder L1 = {
     AnyFloat LTptT11SacrumVia2Node_pos = {.LSNode_pos[0]+0.008,.LSNode_pos[1],(..Thorax.Right.LTptT11SacrumNode_pos[2] - ..Thorax.LTptT11SacrumZ*(..Thorax.Right.LTptT11SacrumNode_pos[1] - .LSNode_pos[1]))};
     AnyFloat LTptT12SacrumVia1Node_pos = {.LSNode_pos[0]+0.010,.LSNode_pos[1],(..Thorax.Right.LTptT12SacrumNode_pos[2] - ..Thorax.LTptT12SacrumZ*(..Thorax.Right.LTptT12SacrumNode_pos[1] - .LSNode_pos[1]))};
     
-    AnyVec3 PML1I_TMNode_pos = {0.054,0.124,0.022}; 
+    AnyVec3 PML1I_TMNode_pos = {0.054, 0.134, 0.022}; 
     AnyVec3 PML1T_TMNode_pos = {0.012,0.137,0.025};
     AnyFloat QLL1_CINode_pos = {0.008000000, 0.1370000, 0.03200000};
     AnyFloat MFL1T8Node_pos = {0.002000000, 0.1360000, 0.02300000};

--- a/Body/AAUHuman/Trunk/TrunkData1.1/ThoracicNodes.any
+++ b/Body/AAUHuman/Trunk/TrunkData1.1/ThoracicNodes.any
@@ -1357,7 +1357,7 @@ AnyFolder Thorax = {
 
     AnyFloat BuckleNode_pos                             = {0.1500000, 0.1800000, 0.1200000};
     
-    AnyVec3 PMT12I_TMNode_pos= {0.040,0.153,0.019}; 
+    AnyVec3 PMT12I_TMNode_pos= {0.04, 0.163, 0.019}; 
                 
     AnyFloat ILptC5SIPSVia1Node_pos    = {-0.050,0.336,(ILptC5SIPSNode_pos[2] - .ILptC5SIPSZ*(ILptC5SIPSNode_pos[1] - 0.336))};
     AnyFloat ILptC5SIPSVia2Node_pos    = {-0.052,0.317,(ILptC5SIPSNode_pos[2] - .ILptC5SIPSZ*(ILptC5SIPSNode_pos[1] - 0.317))};


### PR DESCRIPTION
* Adjust psoas via points and origins

This is a followup to HS's adjustments which solves the problem with erector spinae (sacrum-L5) beeing overloaded when trunk carries an extension moment.

* Update wilke trend validation