### PR TITLE
Improve the way CameraLookAtPoint is set in MoCap Examples

### DIFF
--- a/Application/MocapExamples/ADL_Gait_[beta]/CreateVideo.any
+++ b/Application/MocapExamples/ADL_Gait_[beta]/CreateVideo.any
@@ -13,12 +13,10 @@ VIDEO_STUDY = {
   {
      VideoName = Main.ModelSetup.TrialSpecificData.TrialFileName;
   
-     // The point the camera focus on COM 
-     CameraLookAtPoint = {
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[0],
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[1],
-       0.9
-     };
+
+     // This fixes the "Look at point" at a specific height while still following the center of mass
+     CameraLookAtPoint = 0.9*CameraUpDirection +
+         mult(Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos, not(CameraUpDirection));
      
      // The vertical field of view in meters at the LookAtPoint
      CameraFieldOfView = 2;

--- a/Application/MocapExamples/BVH_Xsens/CreateVideo.any
+++ b/Application/MocapExamples/BVH_Xsens/CreateVideo.any
@@ -13,12 +13,10 @@ VideoLookAtCamera VideoTool (UP_DIRECTION = y) =
 {
      VideoName = Main.ModelSetup.TrialSpecificData.TrialFileName;
   
-     // The point the camera focus on  
-     CameraLookAtPoint = {
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[0],
-       0.9,
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[2]
-     };
+
+     // This fixes the "Look at point" at a specific height while still following the center of mass
+     CameraLookAtPoint = 0.9*CameraUpDirection +
+         mult(Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos, not(CameraUpDirection));
      
      // The vertical field of view in meters at the LookAtPoint
      CameraFieldOfView = 2;

--- a/Application/MocapExamples/BVH_Xsens_OptimizeOrigin/CreateVideo.any
+++ b/Application/MocapExamples/BVH_Xsens_OptimizeOrigin/CreateVideo.any
@@ -13,12 +13,9 @@ VideoLookAtCamera VideoTool (UP_DIRECTION = y) =
 {
      VideoName = Main.ModelSetup.TrialSpecificData.TrialFileName;
   
-     // The point the camera focus on  
-     CameraLookAtPoint = {
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[0],
-       0.9,
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[2]
-     };
+     // This fixes the "Look at point" at a specific height while still following the center of mass
+     CameraLookAtPoint = 0.9*CameraUpDirection +
+         mult(Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos, not(CameraUpDirection));
      
      // The vertical field of view in meters at the LookAtPoint
      CameraFieldOfView = 2;

--- a/Application/MocapExamples/Plug-in-gait_Simple/Setup/CreateVideo.any
+++ b/Application/MocapExamples/Plug-in-gait_Simple/Setup/CreateVideo.any
@@ -24,14 +24,10 @@ VIDEO_STUDY = {
      // The inlcuded FFMPEG only support free codecs (LGPL). You can replace the FFPEG
      // executable in AnyBody's install directory to enable other codecs like "libx264"
      VideoCodec = "libvpx-vp9";
-
-
-     // The point the camera focus on COM 
-     CameraLookAtPoint = {
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[0],
-       0.75,
-       Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos[2]
-     };
+            
+     // This fixes the "Look at point" at a specific height while still following the center of mass
+     CameraLookAtPoint = 0.75*CameraUpDirection +
+         mult(Main.HumanModel.BodyModel.Interface.CenterOfMass.Pos, not(CameraUpDirection));
      
      // The vertical field of view in meters at the LookAtPoint
      CameraFieldOfView = 1.9;


### PR DESCRIPTION
This should make the code robust against changing the UP_DIRECTION of the camera class template. Thanks to @JohnRasmussenAnyBody for pointing to this problem.