### PR TITLE
Add version check

### DIFF
--- a/AMMR.version.any
+++ b/AMMR.version.any
@@ -5,3 +5,13 @@
 #define AMMR_VERSION_PATCH 0
 #endif
 
+// AMMR 2.5 needs atleast AnyBody version 7.5 to work correctly
+#if (ANYBODY_V1 < 7) | (ANYBODY_V1 == 7 & ANYBODY_V2 < 5)
+Main = {
+  AnyMessage NotSupported = {
+  TriggerPreProcess = On;
+  Type = MSG_ErrorFatal;
+  Message = "AnyBody version 7.5 or higher is required for AMMR " + AMMR_VERSION;
+  };
+}; 
+#endif


### PR DESCRIPTION
If AMMR 2.5 is loaded with non supported version of AMS then a more sensible error is triggered: 

```
Constructing model tree...
ERROR(OBJ1) :   AMMR.version.any(10)  :   NotSupported  :  AnyBody version 7.5 or higher is required for AMMR 2.5.0-beta
Model loading skipped
```