### PR TITLE
Add 'Version error' which always works

### DIFF
--- a/AMMR.version.any
+++ b/AMMR.version.any
@@ -9,5 +9,5 @@
 //
 // This model repository needs atleast AnyBody version 7.5 to load correctly
 //
-():NOT_SUPPORTED:__++++++++++++++__AnyBody_v7.5_or_higher_is_required_for_AMMR_v2.5__+++++++++++++++++++__
+#NOT_SUPPORTED__++++++++++++++__AnyBody_v7.5_or_higher_is_required_for_AMMR_v2.5__+++++++++++++++++++__
 #endif


### PR DESCRIPTION
Add version error which triggers early

This new waning message will trigger early. The previously one did not show up if any new syntax was used in the AMMR as that would cause a syntax error before the warning could be rendered.
