### PR TITLE
Add Load parameters operation in Mocap LoadAndReplay operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 % To minimize the risk of merge conflicts insert the your changes at a
 % random empty or make a new entry a random place in the bullet lists.
+## AMMR 2.x.x
+
+**Added:**
+
+**Changed:**
+
+**Fixed:**
+* The `LoadParameters` operation was missing in the `LoadAndReplay` operation in 
+  MoCap examples. This has been fixed.
 
 (ammr-2.4-changelog)=
 ## AMMR 2.4.3 (2023-01-27)

--- a/Tools/AnyMocap/RunApplication.any
+++ b/Tools/AnyMocap/RunApplication.any
@@ -60,6 +60,7 @@ Main = {
   
   AnyOperationSequence LoadAndReplay= 
   {
+      AnyOperation& LoadParameters=  Main.ModelSetup.Macros.Load_parameters;
       AnyOperation& LoadHDF5= Main.ModelSetup.Macros.LoadOutputFromHDF;
       AnyOperation& Replay= Main.Studies.InverseDynamicStudy.Replay;
   };  


### PR DESCRIPTION
The load parameters operation was missing in the mocap LoadAndReplay operation. Consequently, the model would load and replay saved hdf5 files without using the updated parameters. This has been fixed. And changelog has been added.