### PR TITLE
Buckle support

### DIFF
--- a/Body/AAUHuman/Trunk/BuckleSupport.any
+++ b/Body/AAUHuman/Trunk/BuckleSupport.any
@@ -62,6 +62,24 @@ AnyFolder BuckleSupport={
     #include "<ANYBODY_PATH_MODELUTILS>/Reactions/XPush.any"          
     #include "<ANYBODY_PATH_MODELUTILS>/Reactions/XPull.any"          
   };
+  
+  // Stabalizes the buckle in case of very small imbalances. This support has 
+  // a very low strength to ensure it is only used when nothing else is able 
+  // to balance this DOF.
+  AnyRecruitedActuator RotationSupport = {
+    AnyKinMeasureOrg Measure = {
+      AnyKinRotational rot =  {
+        AnyRefFrame& buckle = ....Segments.BuckleSeg;
+        AnyRefFrame& pelvis = .....SegmentsLumbar.PelvisSeg;
+        Type = RotAxesAngles;
+      };
+      MeasureOrganizer = {1};
+    };
+    Type = Bilateral;
+    Strength = 1;
+    SET_DEFAULT_ACTUATOR_VOLUME;
+  };
+
    
 };
 


### PR DESCRIPTION
This is follow-up to #754, and improves the robustness of the buckle. It ensure the oblique muscles are not mis-recruited to balance small moments around vertical axis of the buckle. 