### PR TITLE
Fix load-time position of wrist-joint segment

### DIFF
--- a/Body/AAUHuman/Arm/InitialPositions.any
+++ b/Body/AAUHuman/Arm/InitialPositions.any
@@ -23,7 +23,8 @@ Seg.Humerus.Axes0*
 Seg.Humerus.fe.ARel*
 Seg.Humerus.fe.RotNode.ARel*
 RotMat((pi/180)*.JointPos.ElbowFlexion,x)*
-Seg.Ulna.fe.RotNode.ARel';
+Seg.Ulna.fe.RotNode.ARel'*
+Seg.Ulna.fe.ARel';
 
 
 //right Radius
@@ -31,11 +32,9 @@ Seg.Radius.Axes0 =
 Seg.Ulna.Axes0*
 Seg.Ulna.ps2.ARel*
 Seg.Ulna.ps2.RotNode.ARel*
-//RotMat(-pi/2,z)*
-RotMat(0.0,y)*
 RotMat((pi/180)*.JointPos.ElbowPronation ,x)*
-Seg.Radius.PointPS2.ARel'*
-Seg.Radius.PointPS2.RotNode.ARel';
+Seg.Radius.PointPS2.RotNode.ARel'*
+Seg.Radius.PointPS2.ARel';
 
 
 
@@ -44,8 +43,9 @@ Seg.Radius.PointPS2.RotNode.ARel';
 Seg.WristJointSeg.Axes0 =
 Seg.Radius.Axes0*
 Seg.Radius.wj.ARel*
-RotMat(-(pi/180)*.JointPos.WristFlexion,y)*
-//RotMat((pi/180)*.JointPos.WristAbduction,z)*
+Seg.Radius.wj.RotNode.ARel*
+RotMat((pi/180)*.JointPos.WristFlexion,y)*
+Seg.WristJointSeg.FlexionExtensionAxis.RotNode.ARel'*
 Seg.WristJointSeg.FlexionExtensionAxis.ARel';
 
 
@@ -59,9 +59,10 @@ Seg.WristJointSeg.FlexionExtensionAxis.ARel';
 
 HandSeg.Axes0 =
 Seg.WristJointSeg.Axes0*
-Seg.WristJointSeg.FlexionExtensionAxis.ARel*
-//RotMat((pi/180)*..JointPos.WristAbduction,z)*
-RotMat(Sign*(pi/180)*.JointPos.WristAbduction,z)*
+Seg.WristJointSeg.RadialUlnarDeviation.ARel*
+Seg.WristJointSeg.RadialUlnarDeviation.RotNode.ARel*
+RotMat((pi/180)*.JointPos.WristAbduction,z)*
+Seg.Hand.HandRef.wj.RotNode.ARel'*
 Seg.Hand.HandRef.wj.ARel';
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 **Changed:**
 
 **Fixed:**
+* Fix an issue with the load time position (start guess) of the wrist joint segment. This fix greatly improves the kinematic robustness of all models which have arms. 
+  The wrist joint segment is small intermediate segment between the radius bone and the hand which greates the 'unversal-joint' mechanism of the wrist.  
 * The `LoadParameters` operation was missing in the `LoadAndReplay` operation in 
   MoCap examples. This has been fixed.
 


### PR DESCRIPTION
This fix improves the robustness of all models with arms. 

This will likely fix many of the sporadic kinematic problems we have experience for many years. 

