### PR TITLE
Remove inertia from buclke segment

### DIFF
--- a/Body/AAUHuman/Trunk/Buckle.any
+++ b/Body/AAUHuman/Trunk/Buckle.any
@@ -42,7 +42,7 @@ AnyFolder Buckle={
 
       
       Mass=0.1;
-      Jii={0.1,0.1,0.1};
+      Jii={0,0,0};
       //Set the inital position to be the midpoint between the control point on pelvis and thorax
       r0=0.5*(...SegmentsRibCage.SternalBodySeg.BuckleNodeTopCenter.sRel*...SegmentsRibCage.SternalBodySeg.Axes0'+...SegmentsRibCage.SternalBodySeg.r0+
       ...SegmentsLumbar.PelvisSeg.BuckleNodeBottomCenter.sRel*...SegmentsLumbar.PelvisSeg.Axes0'+...SegmentsLumbar.PelvisSeg.r0);


### PR DESCRIPTION
copilot:all

There is no reason to an inertia for the buckle dummy segment. It only messes with the automatic drawing of inertias in AMS 7.5