### PR TITLE
WIP: Symmetric wrapping cyls

### DIFF
--- a/Body/AAUHuman/LegTLEM/Mus.any
+++ b/Body/AAUHuman/LegTLEM/Mus.any
@@ -109,8 +109,8 @@ AnyMuscleShortestPath SoleusMedialis1 = {
   SPLine = {
     StringMesh = 30;
     AnyMatrix InitWrapPos = {
-      transf3D({1.005*.srf1.Radius, 0, 0.5*.srf1.Length }, &.srf1 ) ,
-      transf3D({-1.005*.srf2.Radius, 0, 0.5*.srf2.Length }, &.srf2 )
+      transf3D({1.005*.srf1.Radius, 0, 0 }, &.srf1 ) ,
+      transf3D({-1.005*.srf2.Radius, 0, 0 }, &.srf2 )
     };
     InitWrapPosVecArr = {&InitWrapPos, None};
   };

--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -803,7 +803,8 @@ AnySeg Shank =
     sRel = .Scale({-0.0336, 0.0987, 0});
     AnySurfCylinder Cyl = {
        Length = 0.2;
-       sRel = {-Radius,0,-0.5*Length};
+       CenterOrigin = On;
+       sRel = {-Radius,0,0};
        Radius = .ShankLengthScale*0.105;
        };
   };
@@ -811,7 +812,8 @@ AnySeg Shank =
     sRel = .Scale({-0.032, 0.0437, 0.000});
     AnySurfCylinder Cyl = {
        Length = 0.2;
-       sRel = {Radius,0,-0.5*Length};
+       CenterOrigin = On;
+       sRel = {Radius,0,0};
        Radius = ..AchillesWrapping1.ShankLengthScale*0.07;
        };
   };


### PR DESCRIPTION
This implements the option to center cylinder around their origin. 

This depends on [AB!274](https://abtv-devops1/AnyBodyTech/Development/_git/ams/pullrequest/274), and should not be merged before the next public beta release if [AB!274](https://abtv-devops1/AnyBodyTech/Development/_git/ams/pullrequest/274) has been approved. 

This should also include a new implementation of the 5-point cylinder fitting class which uses this new approach.

