### PR TITLE
Fix new regresssion with Talus compatibility frame ammr24 symmetry

### DIFF
--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -177,7 +177,7 @@ AnySeg Foot =
     
     /// For backwards compatability with AMMR 2.4 talus coordinate system
     AnyRefNode TalusCompatibilityFrameAMMR24 = {
-      sRel = .Scale({0.006451731, 0.02442938, -0.005543055});
+      sRel = .Scale({0.006451731, 0.02442938, ..Sign*-0.005543055});
       ARel = {{0.9999733, -0.001715394, 0.007107884}, 
               {0.001810773, 0.9999081, -0.01343407}, 
               {-0.007084187, 0.01344658, 0.9998845}};


### PR DESCRIPTION
This is new bug, so no changelog entry is needed. 