### PR TITLE
exclude .devcontainer/ from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,3 +47,4 @@ confidential.txt export-ignore
 Body\AAUHuman\BodyModels\GenericBodyModel\ammr-beta.any export-ignore
 Body\AAUHuman\BodyModels\GenericBodyModel\git_info.py export-ignore
 CHANGELOG.md export-ignore
+.devcontainer export-ignore


### PR DESCRIPTION
No changelog needed