### PR TITLE
Small visual improvements for body model

### DIFF
--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.any
@@ -185,23 +185,10 @@ AnyFolder BodyModel = {
   
   
   AnyFolder Interface = {
-        AnyKinCoM CenterOfMass = {
-          #if  BM_ARM_RIGHT
-          AnyFolder &RightArmSeg = ..Right.ShoulderArm.Seg;
-          #endif
-          #if  BM_ARM_LEFT
-          AnyFolder &LeftArmSeg = ..Left.ShoulderArm.Seg;
-          #endif
-          #if BM_LEG_RIGHT
-          AnyFolder &RightLegSeg = ..Right.Leg.Seg;
-          #endif          
-          #if BM_LEG_LEFT
-          AnyFolder &LeftLegSeg = ..Left.Leg.Seg;
-          #endif
-          AnyFolder &TrunkSegmentsLumbar = ..Trunk.SegmentsLumbar;
-          AnyFolder &TrunkSegmentsThorax = ..Trunk.SegmentsThorax;
-          AnyFolder &TrunkSegmentsCervicalSpine = ..Trunk.SegmentsCervicalSpine;
-        };  
+    AnyKinCoM CenterOfMass = {
+      RefFrames = ObjSearchRecursive( &...BodyModel, "*", "AnySeg");
+    };  
+ 
   };
   
   AnyFolder IndividualMasses = {};

--- a/Body/AAUHuman/BuildTools/render_templates.py
+++ b/Body/AAUHuman/BuildTools/render_templates.py
@@ -1,36 +1,41 @@
-
-import os
 import re
 
 from pathlib import Path
 
 from jinja2 import Template
-import toml
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 
-
-
-tmplpath =  Path(__file__).parent.absolute()
+tmplpath = Path(__file__).parent.absolute()
 
 rootpath = tmplpath.parents[2]
 
-data = toml.load(rootpath / "Body/AAUHuman/bm-parameters.toml")
+with open(rootpath / "Body/AAUHuman/bm-parameters.toml", "rb") as fh:
+    data = tomllib.load(fh)
+
 
 def filterp(match):
     prog = re.compile(match)
-    return {k:v for k,v in data['parameters'].items() if prog.match(k) }
+    return {k: v for k, v in data["parameters"].items() if prog.match(k)}
+
 
 bm_all = filterp(".*")
-bm_leg = filterp('^BM_LEG')
-bm_trunk = filterp('^BM_TRUNK')
-bm_arm = filterp('^BM_ARM')
-bm_scaling = filterp('^BM_SCALING')
-bm_mannequin = filterp('^BM_MANNEQUIN_DRIVER')
-bm_jointtype = filterp('^BM_JOINT_TYPE')
+bm_leg = filterp("^BM_LEG")
+bm_trunk = filterp("^BM_TRUNK")
+bm_arm = filterp("^BM_ARM")
+bm_scaling = filterp("^BM_SCALING")
+bm_mannequin = filterp("^BM_MANNEQUIN_DRIVER")
+bm_jointtype = filterp("^BM_JOINT_TYPE")
 
-used_param = set().union(*[bm_leg, bm_trunk, bm_arm, bm_scaling, bm_mannequin, bm_jointtype])
+used_param = set().union(
+    *[bm_leg, bm_trunk, bm_arm, bm_scaling, bm_mannequin, bm_jointtype]
+)
 
-bm_other ={k: bm_all[k] for k in sorted(set(bm_all) - used_param)}
+bm_other = {k: bm_all[k] for k in sorted(set(bm_all) - used_param)}
 
 
 targets = [
@@ -53,14 +58,12 @@ targets = [
 ]
 
 
-for target,template, data in targets:
+for target, template, data in targets:
     target = rootpath / target
     if not template:
-        template = (target.name + ".jinja")
+        template = target.name + ".jinja"
     template = tmplpath / template
     with open(template) as fh:
         tmpl = Template(fh.read())
     with open(target, "w") as fh:
         fh.write(tmpl.render(data=data))
-
-

--- a/Body/AAUHuman/DrawSettings/MusDrawSettings.any
+++ b/Body/AAUHuman/DrawSettings/MusDrawSettings.any
@@ -1,22 +1,22 @@
-RGB = Main.DrawSettings.Muscle.RGB;
-Bulging = Main.DrawSettings.Muscle.Bulging;
-ColorScale = Main.DrawSettings.Muscle.ColorScale;
-RGBColorScale = Main.DrawSettings.Muscle.RGBColorScale; 
-MaxStress = Main.DrawSettings.Muscle.MaxStress; 
-Opacity = Main.DrawSettings.Muscle.Opacity;
-
+RGB ??= Main.DrawSettings.Muscle.RGB;
+Bulging ??= Main.DrawSettings.Muscle.Bulging;
+ColorScale ??= Main.DrawSettings.Muscle.ColorScale;
+RGBColorScale ??= Main.DrawSettings.Muscle.RGBColorScale; 
+MaxStress ??= Main.DrawSettings.Muscle.MaxStress; 
+Opacity ??= Main.DrawSettings.Muscle.Opacity;
+Visible ??= Main.DrawSettings.Muscle.Visible;
 DrawScaleOnOff=Main.DrawSettings.Muscle.DrawScaleOnOff;
 
 // Applications based on AMMR < 2.0.1 needs an updated DrawSettings.any file.
 // Otherwise the following code will cause an error. 
-DrawScale.EnableCreasing = Main.DrawSettings.Muscle.DrawScale.EnableCreasing;
-DrawScale.CreasingAngle = Main.DrawSettings.Muscle.DrawScale.CreasingAngle;
-DrawScale.EnableWireframe = Main.DrawSettings.Muscle.DrawScale.EnableWireframe;
-DrawScale.EnableSmoothing = Main.DrawSettings.Muscle.DrawScale.EnableSmoothing;
-DrawScale.Param = Main.DrawSettings.Muscle.DrawScale.Param;
-DrawScale.ParamArray = Main.DrawSettings.Muscle.DrawScale.ParamArray;
-DrawScale.RGBArray = Main.DrawSettings.Muscle.DrawScale.RGBArray;
-DrawScale.OpacityArray = Main.DrawSettings.Muscle.DrawScale.OpacityArray;
+DrawScale.EnableCreasing ??= Main.DrawSettings.Muscle.DrawScale.EnableCreasing;
+DrawScale.CreasingAngle ??= Main.DrawSettings.Muscle.DrawScale.CreasingAngle;
+DrawScale.EnableWireframe ??= Main.DrawSettings.Muscle.DrawScale.EnableWireframe;
+DrawScale.EnableSmoothing ??= Main.DrawSettings.Muscle.DrawScale.EnableSmoothing;
+DrawScale.Param ??= Main.DrawSettings.Muscle.DrawScale.Param;
+DrawScale.ParamArray ??= Main.DrawSettings.Muscle.DrawScale.ParamArray;
+DrawScale.RGBArray ??= Main.DrawSettings.Muscle.DrawScale.RGBArray;
+DrawScale.OpacityArray ??= Main.DrawSettings.Muscle.DrawScale.OpacityArray;
 
 
 // Updating the DrawSettings file is easy.

--- a/Body/AAUHuman/LegTLEM/LegMoments.any
+++ b/Body/AAUHuman/LegTLEM/LegMoments.any
@@ -260,9 +260,10 @@ AnyForceMomentMeasure AnkleJointReactionMoments =
 
 #endif
 
-AnyForceMomentMeasure KneeJointReactionMoments = 
+AnyForceMomentMeasure2 KneeJointReactionMoments = 
 {
   AnyForceBase &Force = ..Jnt.Knee.Constraints.Reaction;
   AnyRefFrame &Thighknee = ..Seg.Thigh.KneeJoint;
+  IncludeSegments = {&..Seg.Thigh};
   AnyVec3 Mlocal = M*Thighknee.Axes;
 };

--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -270,8 +270,8 @@ AnySeg Foot =
     
     AnyDrawSurf DrwSurf =
     {
-      FileName = ...STL.FilenameTalus;
-      ScaleXYZ = {1.0, 1.0, ....Sign*1.0};
+      FileName ??= ...STL.FilenameTalus;
+      ScaleXYZ ??= {1.0, 1.0, ....Sign*1.0};
       RGB ??= ....ColorRef.Segments;
       AnyFunTransform3D &Scale =.Scale;
       Opacity ??= ....BonesOpacity.Talus;
@@ -533,8 +533,8 @@ AnySeg Foot =
 
   AnyDrawSurf DrwSurf =
   {
-    FileName = ..STL.FilenameFoot;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
+    FileName ??= ..STL.FilenameFoot;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
     RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
     Opacity ??= ...BonesOpacity.Foot;
@@ -543,10 +543,10 @@ AnySeg Foot =
   #if SKIN
   AnyDrawSurf Drw2 =
   {
-    FileName = ..STL.FilenameFootSkin;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Skin;
-    Opacity = Main.DrawSettings.SkinOpacity.Opacity;
+    FileName ??= ..STL.FilenameFootSkin;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
+    RGB ??= ...ColorRef.Skin;
+    Opacity ??= Main.DrawSettings.SkinOpacity.Opacity;
     AnyFunTransform3D &Scale =.Scale;
     Face=-1;
   };
@@ -555,10 +555,10 @@ AnySeg Foot =
   #if MUSCLETISSUE
   AnyDrawSurf Drw1 =
   {
-    FileName = ..STL.FilenameFootMuscleTissue;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.MuscleTissue;
-    Opacity = Main.DrawSettings.MuscleTissueOpacity.Opacity;
+    FileName ??= ..STL.FilenameFootMuscleTissue;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
+    RGB ??= ...ColorRef.MuscleTissue;
+    Opacity ??= Main.DrawSettings.MuscleTissueOpacity.Opacity;
     AnyFunTransform3D &Scale =.Scale;
     Face=-1;
   };
@@ -957,8 +957,8 @@ AnySeg Shank =
 
   AnyDrawSurf DrwSurfTibia =
   {
-    FileName = ..STL.FilenameShank;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
+    FileName ??= ..STL.FilenameShank;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
     RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
     Opacity ??= ...BonesOpacity.Shank;
@@ -966,8 +966,8 @@ AnySeg Shank =
   };
 
   AnyDrawSurf DrwSurfFibula = {
-    FileName = ..STL.FilenameFibula;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
+    FileName ??= ..STL.FilenameFibula;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
     RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale; 
     Opacity ??= ...BonesOpacity.Shank;
@@ -977,10 +977,10 @@ AnySeg Shank =
   #if SKIN
   AnyDrawSurf Drw2 =
   {
-    FileName = ..STL.FilenameShankSkin;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Skin;
-    Opacity = Main.DrawSettings.SkinOpacity.Opacity;
+    FileName ??= ..STL.FilenameShankSkin;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
+    RGB ??= ...ColorRef.Skin;
+    Opacity ??= Main.DrawSettings.SkinOpacity.Opacity;
     AnyFunTransform3D &Scale =.Scale;
     Face=-1;
   };
@@ -989,10 +989,10 @@ AnySeg Shank =
   #if MUSCLETISSUE
   AnyDrawSurf Drw1 =
   {
-    FileName = ..STL.FilenameShankMuscleTissue;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.MuscleTissue;
-    Opacity = Main.DrawSettings.MuscleTissueOpacity.Opacity;
+    FileName ??= ..STL.FilenameShankMuscleTissue;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
+    RGB ??= ...ColorRef.MuscleTissue;
+    Opacity ??= Main.DrawSettings.MuscleTissueOpacity.Opacity;
     AnyFunTransform3D &Scale =.Scale;
     Face=-1;
   };
@@ -1438,8 +1438,8 @@ AnySeg Thigh =
 
   AnyDrawSurf Drw3 =
   {
-    FileName = ..STL.FilenameThigh;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0}*1;
+    FileName ??= ..STL.FilenameThigh;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0}*1;
     RGB ??= ...ColorRef.Segments;
     Opacity ??= ...BonesOpacity.Thigh;
     AnyFunTransform3D &Scale =.Scale;
@@ -1454,10 +1454,10 @@ AnySeg Thigh =
     ARel = RotMat(...Sign*-27*pi/180, y);
     AnyDrawSurf Drw2 =
     {
-      FileName = ...STL.FilenameThighSkin;
-      ScaleXYZ = {1.0, 1.0, ....Sign*1.0};
-      RGB = ....ColorRef.Skin;
-      Opacity = Main.DrawSettings.SkinOpacity.Opacity;
+      FileName ??= ...STL.FilenameThighSkin;
+      ScaleXYZ ??= {1.0, 1.0, ....Sign*1.0};
+      RGB ??= ....ColorRef.Skin;
+      Opacity ??= Main.DrawSettings.SkinOpacity.Opacity;
       AnyFunTransform3D &Scale =..Scale;
       Face=-1;
     };
@@ -1470,10 +1470,10 @@ AnySeg Thigh =
     sRel = {0,0,0};
     ARel = RotMat(...Sign*-27*pi/180, y);
     AnyDrawSurf Drw2 = {
-      FileName = ...STL.FilenameThighMuscleTissue;
-      ScaleXYZ = {1.0, 1.0, ....Sign*1.0};
-      RGB = ....ColorRef.MuscleTissue;
-      Opacity = Main.DrawSettings.MuscleTissueOpacity.Opacity;
+      FileName ??= ...STL.FilenameThighMuscleTissue;
+      ScaleXYZ ??= {1.0, 1.0, ....Sign*1.0};
+      RGB ??= ....ColorRef.MuscleTissue;
+      Opacity ??= Main.DrawSettings.MuscleTissueOpacity.Opacity;
       AnyFunTransform3D &Scale =..Scale;
       Face=-1;
     };
@@ -1535,8 +1535,8 @@ AnySeg Patella =
   
   AnyDrawSurf DrwSurf =
   {
-   FileName = ..STL.FilenamePatella;
-    ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
+   FileName ??= ..STL.FilenamePatella;
+    ScaleXYZ ??= {1.0, 1.0, ...Sign*1.0};
     RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
     Opacity ??= ...BonesOpacity.Patella;
@@ -1959,9 +1959,9 @@ PelvisSeg =
       AnyDrawSurf DrwPelvis =
       #endif
       {
-        FileName = ..STL.FilenamePelvis;
-        Opacity =  Main.DrawSettings.BonesOpacity.Pelvis;
-        RGB = ...ColorRef.Segments;
+        FileName ??= ..STL.FilenamePelvis;
+        Opacity ??=  Main.DrawSettings.BonesOpacity.Pelvis;
+        RGB ??= ...ColorRef.Segments;
         AnyFunTransform3D &Scale = .AnatomicalFrame.Scale_Leg_Pelvis ;
       };
       
@@ -1971,9 +1971,9 @@ PelvisSeg =
       AnyDrawSurf DrwSacrum =
       #endif
       {
-        FileName = ..STL.FilenameSacrum;
-        Opacity =  Main.DrawSettings.BonesOpacity.Pelvis;
-        RGB = ...ColorRef.Segments;
+        FileName ??= ..STL.FilenameSacrum;
+        Opacity ??=  Main.DrawSettings.BonesOpacity.Pelvis;
+        RGB ??= ...ColorRef.Segments;
         AnyFunTransform3D &Scale = .AnatomicalFrame.Scale_Leg_Pelvis ;
       };
       

--- a/Body/AAUHuman/LegTLEM/Seg.any
+++ b/Body/AAUHuman/LegTLEM/Seg.any
@@ -272,9 +272,9 @@ AnySeg Foot =
     {
       FileName = ...STL.FilenameTalus;
       ScaleXYZ = {1.0, 1.0, ....Sign*1.0};
-      RGB = ....ColorRef.Segments;
+      RGB ??= ....ColorRef.Segments;
       AnyFunTransform3D &Scale =.Scale;
-      Opacity = ....BonesOpacity.Talus;
+      Opacity ??= ....BonesOpacity.Talus;
     };
   }; // end of Talus segment
   
@@ -535,9 +535,9 @@ AnySeg Foot =
   {
     FileName = ..STL.FilenameFoot;
     ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Segments;
+    RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
-    Opacity = ...BonesOpacity.Foot;
+    Opacity ??= ...BonesOpacity.Foot;
   };
 
   #if SKIN
@@ -959,18 +959,18 @@ AnySeg Shank =
   {
     FileName = ..STL.FilenameShank;
     ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Segments;
+    RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
-    Opacity = ...BonesOpacity.Shank;
+    Opacity ??= ...BonesOpacity.Shank;
     Face=-1;
   };
 
   AnyDrawSurf DrwSurfFibula = {
     FileName = ..STL.FilenameFibula;
     ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Segments;
+    RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale; 
-    Opacity = ...BonesOpacity.Shank;
+    Opacity ??= ...BonesOpacity.Shank;
     Face=-1;
   };  
   
@@ -1440,8 +1440,8 @@ AnySeg Thigh =
   {
     FileName = ..STL.FilenameThigh;
     ScaleXYZ = {1.0, 1.0, ...Sign*1.0}*1;
-    RGB = ...ColorRef.Segments;
-    Opacity = ...BonesOpacity.Thigh;
+    RGB ??= ...ColorRef.Segments;
+    Opacity ??= ...BonesOpacity.Thigh;
     AnyFunTransform3D &Scale =.Scale;
     Face=-1;
   };
@@ -1537,9 +1537,9 @@ AnySeg Patella =
   {
    FileName = ..STL.FilenamePatella;
     ScaleXYZ = {1.0, 1.0, ...Sign*1.0};
-    RGB = ...ColorRef.Segments;
+    RGB ??= ...ColorRef.Segments;
     AnyFunTransform3D &Scale =.Scale;
-    Opacity = ...BonesOpacity.Patella;
+    Opacity ??= ...BonesOpacity.Patella;
   };
 
   #if JOINT_TYPE_PATELLATENDON != _JOINT_TYPE_USERDEFINED_

--- a/Body/AAUHuman/LegTLEM/TLEM2.2/STL.any
+++ b/Body/AAUHuman/LegTLEM/TLEM2.2/STL.any
@@ -1,22 +1,22 @@
-AnyFileVar FilenameThigh = "femur";
-AnyFileVar FilenameShank = "tibia";
-AnyFileVar FilenameFibula = "fibula";
-AnyFileVar FilenamePelvis = "pelvis";
-AnyFileVar FilenameSacrum = "SacrumSymmSeg";
-AnyFileVar FilenameFoot = "foot";
-AnyFileVar FilenamePatella = "patella";
-AnyFileVar FilenameTalus = "talus";
+AnyFileVar FilenameThigh ??= "femur";
+AnyFileVar FilenameShank ??= "tibia";
+AnyFileVar FilenameFibula ??= "fibula";
+AnyFileVar FilenamePelvis ??= "pelvis";
+AnyFileVar FilenameSacrum ??= "SacrumSymmSeg";
+AnyFileVar FilenameFoot ??= "foot";
+AnyFileVar FilenamePatella ??= "patella";
+AnyFileVar FilenameTalus ??= "talus";
 
-AnyFileVar FilenameThighSkin = "Cad3_Femur_Skin_ISB";
-AnyFileVar FilenameShankSkin = "Cad3_Tibia_Skin_ISB";
-AnyFileVar FilenamePelvisSkin = "Cad3_Pelvis_Skin_ISB";
-AnyFileVar FilenameFootSkin = "Foot_Skin_ISB";
+AnyFileVar FilenameThighSkin ??= "Cad3_Femur_Skin_ISB";
+AnyFileVar FilenameShankSkin ??= "Cad3_Tibia_Skin_ISB";
+AnyFileVar FilenamePelvisSkin ??= "Cad3_Pelvis_Skin_ISB";
+AnyFileVar FilenameFootSkin ??= "Foot_Skin_ISB";
 
-AnyFileVar FilenameThighMuscleTissue = "Cad3_Femur_MuscleTissue_ISB";
-AnyFileVar FilenameShankMuscleTissue = "Cad3_Tibia_MuscleTissue_ISB";
-AnyFileVar FilenamePelvisMuscleTissue = "Cad3_Pelvis_MuscleTissue_ISB";
-AnyFileVar FilenameFootMuscleTissue = "Foot_Muscles_ISB";
+AnyFileVar FilenameThighMuscleTissue ??= "Cad3_Femur_MuscleTissue_ISB";
+AnyFileVar FilenameShankMuscleTissue ??= "Cad3_Tibia_MuscleTissue_ISB";
+AnyFileVar FilenamePelvisMuscleTissue ??= "Cad3_Pelvis_MuscleTissue_ISB";
+AnyFileVar FilenameFootMuscleTissue ??= "Foot_Muscles_ISB";
 
-AnyFileVar FilenameThighMorphing = "cad 3 femur ISB final";
-AnyFileVar FilenameShankMorphing = "cad 3 tibia fibula ISB final";
-AnyFileVar FilenamePelvisMorphing = "cad 3 pelvis ISB final HIP";
+AnyFileVar FilenameThighMorphing ??= "cad 3 femur ISB final";
+AnyFileVar FilenameShankMorphing ??= "cad 3 tibia fibula ISB final";
+AnyFileVar FilenamePelvisMorphing ??= "cad 3 pelvis ISB final HIP";

--- a/Body/AAUHuman/Trunk/RibCageMuscleNodes.any
+++ b/Body/AAUHuman/Trunk/RibCageMuscleNodes.any
@@ -13,8 +13,8 @@ SegmentsRibCage = {
     AnyRefNode R1NodeL                 ={ sRel =.Scale (.StdPar.Sternum.Left.R1Node_pos);};
     AnyRefNode R2NodeL                 ={ sRel =.Scale (.StdPar.Sternum.Left.R2Node_pos);};
 
-    AnyRefNode LumpedHyoidStC0NodeRIns = {sRel = .Scale(.StdPar.Sternum.Right.LumpedHyoidStC0Ins_pos); AnyDrawNode n={ScaleXYZ={1,1,1}*0.00125;RGB={1,0,0};};};
-    AnyRefNode LumpedHyoidStC0NodeLIns = {sRel = .Scale(.StdPar.Sternum.Left.LumpedHyoidStC0Ins_pos); AnyDrawNode n={ScaleXYZ={1,1,1}*0.00125;RGB={1,0,0};};};
+    AnyRefNode LumpedHyoidStC0NodeRIns = {sRel = .Scale(.StdPar.Sternum.Right.LumpedHyoidStC0Ins_pos);};
+    AnyRefNode LumpedHyoidStC0NodeLIns = {sRel = .Scale(.StdPar.Sternum.Left.LumpedHyoidStC0Ins_pos);};
   };
   
     SternalBodySeg = {

--- a/Body/AAUHuman/Trunk/SegmentsCervicalSpine.any
+++ b/Body/AAUHuman/Trunk/SegmentsCervicalSpine.any
@@ -26,7 +26,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
 	
     AnyRefNode C2C1JntNode = {sRel = .Scale(.StdPar.C2C1JntNode_pos);};        
-    AnyRefNode C1C0JntNode = {sRel = .Scale(.StdPar.C1C0JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C1C0JntNode = {sRel = .Scale(.StdPar.C1C0JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
     
     //Longus colli nodes
     AnyRefNode LongusColliT1C1NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C1Node_pos);};
@@ -72,7 +72,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     
     AnyRefNode C3C2JntNode = {sRel = .Scale(.StdPar.C3C2JntNode_pos);};        
-    AnyRefNode C2C1JntNode = {sRel = .Scale(.StdPar.C2C1JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C2C1JntNode = {sRel = .Scale(.StdPar.C2C1JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
 	    
     //Longus colli nodes
     AnyRefNode LongusColliT1C2NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C2Node_pos);};
@@ -129,7 +129,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     
     AnyRefNode C4C3JntNode = {sRel = .Scale(.StdPar.C4C3JntNode_pos);};        
-    AnyRefNode C3C2JntNode = {sRel = .Scale(.StdPar.C3C2JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C3C2JntNode = {sRel = .Scale(.StdPar.C3C2JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
     
     //Longus colli nodes
     AnyRefNode LongusColliT1C3NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C3Node_pos);};
@@ -197,7 +197,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     
     AnyRefNode C5C4JntNode = {sRel = .Scale(.StdPar.C5C4JntNode_pos);};        
-    AnyRefNode C4C3JntNode = {sRel = .Scale(.StdPar.C4C3JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C4C3JntNode = {sRel = .Scale(.StdPar.C4C3JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
     
     //Longus colli nodes
     AnyRefNode LongusColliT1C4NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C4Node_pos);};
@@ -265,7 +265,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
 	
     AnyRefNode C6C5JntNode = {sRel = .Scale(.StdPar.C6C5JntNode_pos);};        
-    AnyRefNode C5C4JntNode = {sRel = .Scale(.StdPar.C5C4JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C5C4JntNode = {sRel = .Scale(.StdPar.C5C4JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
     
     //Longus colli nodes
     AnyRefNode LongusColliT1C5NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C5Node_pos);};
@@ -336,7 +336,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     
     AnyRefNode C7C6JntNode = {sRel = .Scale(.StdPar.C7C6JntNode_pos);};        
-    AnyRefNode C6C5JntNode = {sRel = .Scale(.StdPar.C6C5JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C6C5JntNode = {sRel = .Scale(.StdPar.C6C5JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
     
     //Longus colli nodes
     AnyRefNode LongusColliT1C6NodeR = {sRel = .Scale(.StdPar.Right.LongusColliT1C6Node_pos);};
@@ -406,7 +406,7 @@ AnyFolder SegmentsCervicalSpine = {
     AnyRefNode MoCapMarkerFrameAMMR24 = {}; ///< For backwards Compatibility with AMMR 2.4 MoCap Marker protocols
     
     AnyRefNode T1C7JntNode = {sRel = .Scale(.StdPar.T1C7JntNode_pos);};        
-    AnyRefNode C7C6JntNode = {sRel = .Scale(.StdPar.C7C6JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
+    AnyRefNode C7C6JntNode = {sRel = .Scale(.StdPar.C7C6JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};};        
 
     //Splenius capitis nodes
     AnyRefNode SpleniusCapitisC7C0NodeR = {sRel = .Scale(.StdPar.Right.SpleniusCapitisC7C0Node_pos);};

--- a/Body/AAUHuman/Trunk/SegmentsLumbar.any
+++ b/Body/AAUHuman/Trunk/SegmentsLumbar.any
@@ -135,7 +135,7 @@ AnyFolder SegmentsLumbar = {
     AnyRefNode L5SacrumJntNode = {sRel = .Scale(.StdPar.L5SacrumJntNode_pos);};        
     AnyRefNode L4L5JntNode = {
       sRel = .Scale(.StdPar.L4L5JntNode_pos); 
-      AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
+      AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
       // Rotated node with x axis parallel to the superior endplate surface
       AnyRefNode RotNode = {
         ARel = RotMat(0.5*(..SuperiorEndplateAnteriorNode.sRel + ..SuperiorEndplatePosteriorNode.sRel),..SuperiorEndplateAnteriorNode.sRel,..MidPoint.sRel)*RotMat(pi,x);
@@ -288,7 +288,7 @@ AnyFolder SegmentsLumbar = {
     AnyRefNode L4L5JntNode = {sRel = .Scale(.StdPar.L4L5JntNode_pos);};
     AnyRefNode L3L4JntNode = {
       sRel = .Scale(.StdPar.L3L4JntNode_pos); 
-      AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};
+       AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};
       // Rotated node with x axis parallel to the superior endplate surface
       AnyRefNode RotNode = {
         ARel = RotMat(0.5*(..SuperiorEndplateAnteriorNode.sRel + ..SuperiorEndplatePosteriorNode.sRel),..SuperiorEndplateAnteriorNode.sRel,..MidPoint.sRel)*RotMat(pi,x);
@@ -450,7 +450,7 @@ AnyFolder SegmentsLumbar = {
     AnyRefNode L3L4JntNode = {sRel = .Scale(.StdPar.L3L4JntNode_pos);};    
     AnyRefNode L2L3JntNode = {
       sRel = .Scale(.StdPar.L2L3JntNode_pos); 
-      AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
+       AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
       // Rotated node with x axis parallel to the superior endplate surface
       AnyRefNode RotNode = {
         ARel = RotMat(0.5*(..SuperiorEndplateAnteriorNode.sRel + ..SuperiorEndplatePosteriorNode.sRel),..SuperiorEndplateAnteriorNode.sRel,..MidPoint.sRel)*RotMat(pi,x);
@@ -640,7 +640,7 @@ AnyFolder SegmentsLumbar = {
     AnyRefNode L2L3JntNode = {sRel = .Scale(.StdPar.L2L3JntNode_pos);};    
     AnyRefNode L1L2JntNode = {
       sRel = .Scale(.StdPar.L1L2JntNode_pos); 
-      AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
+       AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1,0,0};};
       // Rotated node with x axis parallel to the superior endplate surface
       AnyRefNode RotNode = {
         ARel = RotMat(0.5*(..SuperiorEndplateAnteriorNode.sRel + ..SuperiorEndplatePosteriorNode.sRel),..SuperiorEndplateAnteriorNode.sRel,..MidPoint.sRel)*RotMat(pi,x);
@@ -824,7 +824,7 @@ AnyFolder SegmentsLumbar = {
     AnyRefNode L1L2JntNode = {sRel = .Scale(.StdPar.L1L2JntNode_pos);};    
     AnyRefNode T12L1JntNode = {
       sRel = .Scale(.StdPar.T12L1JntNode_pos); 
-      AnyDrawNodes DrwNode = {ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};
+       AnyDrawNodes DrwNode = {Visible ??=..DrwSTL.Visible; ScaleXYZ = 0.003*{1,1,1};RGB = {1, 0, 0};};
       // Rotated node with x axis parallel to the superior endplate surface
       AnyRefNode RotNode = {
         ARel = RotMat(0.5*(..SuperiorEndplateAnteriorNode.sRel + ..SuperiorEndplatePosteriorNode.sRel),..SuperiorEndplateAnteriorNode.sRel,..MidPoint.sRel)*RotMat(pi,x);

--- a/Body/AAUHuman/Trunk/SkullSeg.any
+++ b/Body/AAUHuman/Trunk/SkullSeg.any
@@ -23,7 +23,7 @@
     sCoM = Scale(StdPar.sCoM_pos);
     JaboutCoMOnOff = On;
     
-    AnyRefNode C1C0JntNode = {sRel = .Scale(.StdPar.C1C0JntNode_pos);AnyDrawNodes DrwNode = {ScaleXYZ = {1,1,1}*0.003;RGB = {0, 1, 0};};};
+    AnyRefNode C1C0JntNode = {sRel = .Scale(.StdPar.C1C0JntNode_pos); AnyDrawNodes DrwNode = {Visible ??=..DrwSurf.Visible; ScaleXYZ = {1,1,1}*0.003;RGB = {0, 1, 0};};};
     AnyRefNode NeckNode={sRel=.Scale(.StdPar.NeckNode_pos);};
     
     //Lumped Hyoid

--- a/Tools/ModelUtilities/Drivers/Fourier.any
+++ b/Tools/ModelUtilities/Drivers/Fourier.any
@@ -1,0 +1,25 @@
+#ifndef MODEL_UTILITIES_DRIVERS_FOURIER_ANY
+#define MODEL_UTILITIES_DRIVERS_FOURIER_ANY
+
+
+
+#class_template SimpleFourierDriver(__CLASS__=AnyKinEqFourierDriver, _REDEFINE_INPUTS=Off){
+
+   #if _REDEFINE_VARIABLES != On
+   AnyFloat RangeOfMotion ??= {-50,50};
+   AnyVar Phase ??= 180;
+   #var Freq = 1;
+   #endif
+   
+   
+   #var Type = Cos;
+   #var A = 0.5*{{RangeOfMotion[1]+RangeOfMotion[0], abs(RangeOfMotion[1]- RangeOfMotion[0])}};
+   #var B = {{0, Phase}};
+   
+};
+
+#endif
+
+
+
+


### PR DESCRIPTION
This PR cherry-picks a few visual improvements from #874. 

* It implements the Center Of Mass measure in the `Interface` folder using search functions. It ensures segments are not picked up by accident when including the `interface` folder in a study.
* It links some `Visible` of nodes in the spine to the `Visible` setting of the bone. This makes it easier to hide segments with a single line of code.
* It links the Muscle visible setting to the `visible` setting in `DrawSetting`. I think it is a bug that it did not do that already.