### PR TITLE
Fix typos in variable name

### DIFF
--- a/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
+++ b/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
@@ -66,7 +66,7 @@ SelectedOutput.Trunk = {
     //L1 ref
     
     /// Lateral (right) positive
-    AnyVar C1FMedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
+    AnyVar C1T1MedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
     /// Distal (superior) positive
     AnyVar C7T1CompressionForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[1];
     /// Anterior positive

--- a/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
+++ b/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
@@ -66,7 +66,7 @@ SelectedOutput.Trunk = {
     //L1 ref
     
     /// Lateral (right) positive
-    AnyVar C1T1MedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
+    AnyVar C7T1MedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
     /// Distal (superior) positive
     AnyVar C7T1CompressionForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[1];
     /// Anterior positive

--- a/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
+++ b/Body/AAUHuman/Trunk/SelectedOutput/TrunkSelectedOutput.any
@@ -66,11 +66,11 @@ SelectedOutput.Trunk = {
     //L1 ref
     
     /// Lateral (right) positive
-    AnyVar C1T7MedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
+    AnyVar C1FMedioLateralShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[2];
     /// Distal (superior) positive
-    AnyVar C1T7CompressionForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[1];
+    AnyVar C7T1CompressionForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[1];
     /// Anterior positive
-    AnyVar C1T7AnteroPosteriorShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[0];
+    AnyVar C7T1AnteroPosteriorShearForce = ...Trunk.JointsCervicalSpine.T1C7Jnt.ReactionForceRotated.Flocal[0];
     //Thorax ref
     
     /// Lateral (right) positive


### PR DESCRIPTION
Two selected output variables was named `C1T7` instead of `C7T1` 