### PR TITLE
CI: cache key is needed when cache-write key is given

### DIFF
--- a/.github/workflows/ammr-doc.yaml
+++ b/.github/workflows/ammr-doc.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.5.0
         with:
           environments: docs
+          cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
   
       - name: Link check
@@ -62,6 +63,7 @@ jobs:
         id: pixisetup
         with:
             environments: docs
+            cache: true
             cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
   
       - name: Build Documentation

--- a/.github/workflows/create-compare-reference.yml
+++ b/.github/workflows/create-compare-reference.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.5.0
         with:
           environments: test
+          cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
           post-cleanup: true
     

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.5.0
         with:
           environments: test
+          cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         
       - name: Run full AMMR tests

--- a/.github/workflows/test-self-hosted.yml
+++ b/.github/workflows/test-self-hosted.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           environments: test
           pixi-bin-path: ${{ runner.temp }}\Scripts\pixi.exe
+          cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
           post-cleanup: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.5.0
         with:
           environments: test
+          cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         
       - name: Patch with custom version


### PR DESCRIPTION
This PR adds back the `cache: true` key to "setup-pixi", in the cases where we also specify `cache-write`. It seems to be needed. 
