### PR TITLE
fix(trunk): Fixed penetration warning for the pectoralis

### DIFF
--- a/Body/AAUHuman/Arm/AddOnOutSideBlockForMuscles.any
+++ b/Body/AAUHuman/Arm/AddOnOutSideBlockForMuscles.any
@@ -101,6 +101,7 @@ ThoraxSegRef ={
   // Ellipsoid which are used for wrapping of pectoralis.
   AnySurfEllipsoid PectoralisWrappingSurface = { 
     sRel = .Scale(...Trunk.SegmentsThorax.ThoraxSeg.StdPar.Thorax.ij_EllipsoidPectoralisOrigin_pos)*.Mirror;  // Helm 1992 subject k2.
+    ARel = RotMat(5*pi/180, x);
     
     //This is the standard values of the elipsoid before any scaling
     AnyVec3 RadiusUnscaled = {0.15, 0.145, 0.10}; 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+(ammr-3.0.2-changelog)=
+## AMMR 3.0.2 (2024-02-13)
+
+### 🩹 Fixed:
+* Fixed a penetration warnings for the pectoralis muscles when the thoracic segments is scale very non-uniformly.
+  The fix involves a small (5 deg) adjustments to the orientation of the pectoralis wrapping surface. 
+
+
 (ammr-3.0.1-changelog)=
 ## AMMR 3.0.1 (2024-02-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## AMMR 3.0.2 (2024-02-13)
 
 ### 🩹 Fixed:
-* Fixed a penetration warnings for the pectoralis muscles when the thoracic segments is scale very non-uniformly.
+* Fixed a penetration warning for the pectoralis muscles when the thoracic segments is scaled very non-uniformly.
   The fix involves a small (5 deg) adjustments to the orientation of the pectoralis wrapping surface. 
 
 

--- a/Tests/Applications/test_ExoConcept_BoxLift.any
+++ b/Tests/Applications/test_ExoConcept_BoxLift.any
@@ -5,7 +5,7 @@
 //    {'EXO_CONCEPT':'4'}, 
 //]
 //ignore_errors = ["Orientation close to Gimbal Lock"]
-
+//fatal_warnings = ["Penetration of surface"]
 
 #include "../libdef.any"
 


### PR DESCRIPTION
Fixed a penetration warnings for the pectoralis muscles when the thoracic segments is scale very non-uniformly.
  The fix involves a small (5 deg) adjustments to the orientation of the pectoralis wrapping surface. 