### PR TITLE
fix(bvh-protocol): Update foot markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+### 🔧 Changed:
+
+* The foot marker position in the Xsens protocol has been changed to account for the changes at the ankle joint in TLEM 2.2 leg model. The R/LTOE and
+  R/LTOE2 markers have been moved upwards by 1.5 cm.
+
 (ammr-3.0.1-changelog)=
 ## AMMR 3.0.1 (2024-02-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+(ammr-3.0.2-changelog)=
+## AMMR 3.0.2 (2024-**-**)
+
 ### 🔧 Changed:
 
 * The foot marker position in the Xsens protocol has been changed to account for the changes at the ankle joint in TLEM 2.2 leg model. The R/LTOE and
-  R/LTOE2 markers have been moved upwards by 1.5 cm.
+  R/LTOE2 markers have been moved upwards by 1.5 cm. 
 
 (ammr-3.0.1-changelog)=
 ## AMMR 3.0.1 (2024-02-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 (ammr-3.0.2-changelog)=
 ## AMMR 3.0.2 (2024-**-**)
 
-### 🔧 Changed:
+### 🩹 Fixed:
 
-* The foot marker position in the Xsens protocol has been changed to account for the changes at the ankle joint in TLEM 2.2 leg model. The R/LTOE and
+* The foot marker position in the Xsens protocol has been updated to account for the changes to the foot anatomical frame introduced with the TLEM 2.2 leg model. The R/LTOE and
   R/LTOE2 markers have been moved upwards by 1.5 cm. 
 
 (ammr-3.0.1-changelog)=

--- a/Tools/AnyMocap/Protocols/XsensBVH.any
+++ b/Tools/AnyMocap/Protocols/XsensBVH.any
@@ -442,7 +442,7 @@ ScaleMarkerPosOnOff =ON,
 USE_BVH_INPUT = ON
 ) = 
 {
- sRelOpt =  {0.14, -0.095, -0.02};
+ sRelOpt =  {0.14, -0.08, -0.02};
  sRelOnBVH = {0.02, 0, 0 };
 }; 
 
@@ -458,7 +458,7 @@ ScaleMarkerPosOnOff =ON,
 USE_BVH_INPUT = ON
 ) = 
 {
- sRelOpt =  {0.14, -0.095, 0.05};
+ sRelOpt =  {0.14, -0.08, 0.05};
  sRelOnBVH = {-0.05, 0, 0 };
 }; 
 
@@ -522,7 +522,7 @@ ScaleMarkerPosOnOff =ON,
 USE_BVH_INPUT = ON
 ) = 
 {
- sRelOpt =  {0.14, -0.095, 0.02}; 
+ sRelOpt =  {0.14, -0.08, 0.02}; 
  sRelOnBVH = {-0.02, 0, 0 };
 };
 
@@ -538,6 +538,6 @@ ScaleMarkerPosOnOff =ON,
 USE_BVH_INPUT = ON
 ) = 
 {
- sRelOpt =  {0.14, -0.095, -0.05};
+ sRelOpt =  {0.14, -0.08, -0.05};
  sRelOnBVH = {0.05, 0, 0 };
 };


### PR DESCRIPTION
The changes to the ankle joint in TLEM 2.2 model resulted in a different calculation of the ankle plantarflexion angle in bvh models. This PR updates the feet marker position in the Xsens protocol to counter the introduced offset. The markers have been moved closer to the foot by 1.5 cm (Y axis).
Changelog entry is added as well.