### PR TITLE
fix(ci): Update the custom-anybodycon github-action to work with pixi

### DIFF
--- a/.github/actions/custom-anybodycon/action.yml
+++ b/.github/actions/custom-anybodycon/action.yml
@@ -36,4 +36,4 @@ runs:
     - name: Update AnyBodyCon version
       shell: powershell
       run: |
-        cp ${{ runner.temp }}\${{ inputs.custom-anybodycon }} "{{ inputs.target-path }}"
+        cp ${{ runner.temp }}\${{ inputs.custom-anybodycon }} "${{ inputs.target-path }}"

--- a/.github/actions/custom-anybodycon/action.yml
+++ b/.github/actions/custom-anybodycon/action.yml
@@ -11,11 +11,11 @@ inputs:
   connection-string:
     description: 'The connection string to the Azure Blob storage'
     required: true
-  overwrite:
-    description: 'Overwrite the AnyBodyCon version in the GitHub runner'
-    required: false
-    default: false
-    
+  target-path:
+    description: 'Where to place the custom AnyBodyCon version.'
+    required: true
+
+
 runs:
   using: "composite"
   steps: 
@@ -33,24 +33,7 @@ runs:
         blob-name: ${{ inputs.custom-anybodycon }}
         download-path: ${{ runner.temp }}
       
-    - name: Update AnyBodyCon environment variable
-      if: ${{ ! inputs.overwrite }}
+    - name: Update AnyBodyCon version
       shell: powershell
       run: |
-        cp ${{ runner.temp }}\${{ inputs.custom-anybodycon }} "$(split-path $Env:ANYBODYCON -Parent)/AnyBodyConCustom.any"
-        echo "ANYBODYCON=$(split-path $Env:ANYBODYCON -Parent)\AnyBodyConCustom.any" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-
-    - name: Overwrite existing AnyBodyCon version
-      if: ${{ inputs.overwrite }}
-      shell: powershell
-      run: |
-        $anybodycon = (get-command anybodycon.exe -ErrorAction SilentlyContinue).path
-        if (-Not $anybodycon) {
-          $anybodycon = (Get-ItemProperty -Path "Registry::HKEY_CLASSES_ROOT\AnyBody.AnyScript\shell\open\command" -Name "(default)")."(default)"
-          $anybodycon = $anybodycon.split('"')[2]
-        }
-        cp ${{ runner.temp }}\${{ inputs.custom-anybodycon }} "$anybodycon"
-
-
-
-  
+        cp ${{ runner.temp }}\${{ inputs.custom-anybodycon }} "{{ inputs.target-path }}"

--- a/.github/workflows/test-self-hosted.yml
+++ b/.github/workflows/test-self-hosted.yml
@@ -53,10 +53,15 @@ jobs:
         with:
           custom-anybodycon: ${{ inputs.custom-anybodycon-name }}
           connection-string:  ${{ secrets.AZURE_CONN_STR }}
+          target-path: .pixi/envs/test/bin/AnyBodyConCustom.exe
+
+      - name: Set custom AnyBodyCon environment variable
+        if: inputs.use-custom-anybodycon
+        run: |
+          echo "ANYBODYCON=.pixi/envs/test/bin/AnyBodyConCustom.exe" >> $GITHUB_ENV
 
       - name: Run AMMR tests
         shell: pixi run -e test pwsh -Command {0}
-
         run: |
           cd Tests
           pytest -n 5 --dist worksteal `

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           custom-anybodycon: ${{ inputs.custom-anybodycon-name }}
           connection-string:  ${{ secrets.AZURE_CONN_STR }}
-          overwrite: true
+          target-path: .pixi/envs/test/bin/AnyBodyCon.exe
             
       - name: Run AMMR tests
         run: |


### PR DESCRIPTION
Fixes the special GitHub action which allows us to run ci tests with a custom anybody version. The action stopped working when we started to installing AnyBody from conda-packages with pixi. 