### PR TITLE
ci(test): Reenable the wheelchair test

### DIFF
--- a/Tests/Applications/test_WheelChairRancho.any
+++ b/Tests/Applications/test_WheelChairRancho.any
@@ -1,4 +1,3 @@
-//expect_errors=["extrapolations are not allowed"]
 //save_study=["Main.Study"]
 
 #include "../libdef.any"


### PR DESCRIPTION
AnyBody 8.0.2 fixes an issue interpolation error in the wheelchair ranco model. Since the tests now run on 8.0.2 we can reenable the test. 