### PR TITLE
ci: enable pr titel validation for forks

### DIFF
--- a/.github/workflows/conventional-commits-in-pr.yml
+++ b/.github/workflows/conventional-commits-in-pr.yml
@@ -1,11 +1,12 @@
 name: PR Conventional Commit Validation
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled]
 
 jobs:
   validate-pr-title:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') && github.event.pull_request.head.repo.fork }}
     permissions:
        pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only for forks marked 'safe to test'