### PR TITLE
ci: pin specicfic github actions for PR title validation

### DIFF
--- a/.github/workflows/conventional-commits-in-pr.yml
+++ b/.github/workflows/conventional-commits-in-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@1.1.0
+        uses:  ytanikin/PRConventionalCommits@8d258b5
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           custom_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'


### PR DESCRIPTION
This unreleased version should fix an issues with labels beeing overwritten.