### PR TITLE
fix: Range of Motion limit class template bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## AMMR 3.0.2 (2024-**-**)
 
 ### 🩹 Fixed:
+* Fixed default limits in [Range of Motion limits](#Utilities.Kinematic-limits.RangeOfMotionLimits_template.any) class template. The default limits for PelvisThoraxExtension, PelvisThoraxLateralBending,
+  Right/LeftWristFlexion had the upper and lower limits flipped. This is now fixed and a check is added in the class template to catch this kind of error.
 * Fixed a penetration warning for the pectoralis muscles when the thoracic segments is scaled very non-uniformly.
   The fix involves a small (5 deg) adjustments to the orientation of the pectoralis wrapping surface. 
 

--- a/Tools/ModelUtilities/KinematicLimits/KinLimit_template.any
+++ b/Tools/ModelUtilities/KinematicLimits/KinLimit_template.any
@@ -92,6 +92,8 @@ float smoothramp(float edge0, float edge1, float x)
   
 #var AnyVar LowerLimit; 
 #var AnyVar HighLimit;
+
+AnyInt LowerHighCheck = assert(gteqfun(HighLimit, LowerLimit), "HighLimit must be greater than LowLimit: " + CompleteNameOf(ObjGetParent(1)));
   
 #var AnyVar DriverPhaseIn = 0.01*(HighLimit - LowerLimit) ;
 #var AnyVar LowerLimitHard= LowerLimit - DriverPhaseIn ;
@@ -109,7 +111,7 @@ AnyFunInterpol AbscissaFunction =
 {
   AnyFloat LowPhaseIn = abs(.LowerLimit-.LowerLimitHard);
   AnyFloat HighPhaseIn = abs(.HighLimit-.HighLimitHard);
-  AnyFloat TotalRange = abs(.LowerLimitHard-.HighLimitHard);
+  AnyFloat TotalRange = abs(.LowerLimitHard-.HighLimitHard) + 0*.LowerHighCheck; // force calculation of LowerHighCheck before error in interpolation function.
 
   #var Type = Bspline;
   #var BsplineOrder = 8;

--- a/Tools/ModelUtilities/KinematicLimits/RangeOfMotionLimits_template.any
+++ b/Tools/ModelUtilities/KinematicLimits/RangeOfMotionLimits_template.any
@@ -156,10 +156,10 @@ See below for more information on how to use the class.
       {
          //RangeOfMotionLimits.Limits.Trunk
          /// The limits for PelvisThoraxExtension
-         #var AnyVector PelvisThoraxExtension          = DesignVar({ 30, -80});
+         #var AnyVector PelvisThoraxExtension          = DesignVar({ -80, 30});
          //RangeOfMotionLimits.Limits.Trunk
          /// The limits for PelvisThoraxLateralBending
-         #var AnyVector PelvisThoraxLateralBending     = DesignVar({ 40, -40});
+         #var AnyVector PelvisThoraxLateralBending     = DesignVar({ -40, 40});
          //RangeOfMotionLimits.Limits.Trunk
          /// The limits for PelvisThoraxRotation
          #var AnyVector PelvisThoraxRotation           = DesignVar({-90,  90});
@@ -201,7 +201,7 @@ See below for more information on how to use the class.
          #var AnyVector ElbowPronation                 = DesignVar({-90,  90});
          //RangeOfMotionLimits.Limits.Right
          /// The limits for WristFlexion
-         #var AnyVector WristFlexion                   = DesignVar({90,  -90});
+         #var AnyVector WristFlexion                   = DesignVar({-90,  90});
          //RangeOfMotionLimits.Limits.Right
          /// The limits for WristAbduction
          #var AnyVector WristAbduction                 = DesignVar({-30,  30});
@@ -252,7 +252,7 @@ See below for more information on how to use the class.
          #var AnyVector ElbowPronation                 = DesignVar({-90,  90});
          //RangeOfMotionLimits.Limits.Left
          /// The limits for WristFlexion
-         #var AnyVector WristFlexion                   = DesignVar({90,  -90});
+         #var AnyVector WristFlexion                   = DesignVar({-90,  90});
          //RangeOfMotionLimits.Limits.Left
          /// The limits for WristAbduction
          #var AnyVector WristAbduction                 = DesignVar({-30,  30});


### PR DESCRIPTION
This PR fixes a small bug in the Range of Motion Limit class template. 4 of the joints had the upper and lower limit swapped: PelvisThoraxExtension, PelvisThoraxLateralBending, Right and Left WristFlexion. These have been fixed.
Moreover, a check has been added in the in the KinLimitsDriver template to check that lower limit is lower than the higher limit.
Changelog entry is also added.