### PR TITLE
fix: Add switch for excluding thoracic support in full body bike model

### DIFF
--- a/Application/Examples/BikeModel/Model/JointsAndDrivers.any
+++ b/Application/Examples/BikeModel/Model/JointsAndDrivers.any
@@ -10,6 +10,8 @@ AnyFolder &JntVel=..Mannequin.PostureVel;
    AnyKinMeasure& Left = Main.HumanModel.BodyModel.Interface.Left.SubTalarEversion;
  };
 
+#if BM_ARM_RIGHT != ON & BM_ARM_LEFT != ON 
+
 /// Support of the upper body to compensate for lack of arms resting on the handlebar
 AnyReacForce Thoraxsupport = {
   AnyKinLinear lin = {
@@ -21,6 +23,7 @@ AnyReacForce Thoraxsupport = {
   };
 };
 
+#endif
 
 Main.HumanModel.BodyModel.Trunk.SegmentsLumbar.PelvisSeg = 
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+(ammr-3.0.4-changelog)=
+## AMMR 3.0.4 (2024-xx-xx)
+
+### 🩹 Fixed:
+* Fixed an issue in the {ref}`Bike Model example <example_bikemodel>` that included thoracic support
+  in the full body model also.
+
 (ammr-3.0.3-changelog)=
 ## AMMR 3.0.3 (2024-06-10)
 [![Zenodo link](https://zenodo.org/badge/DOI/10.5281/zenodo.11191711.svg)](https://doi.org/10.5281/zenodo.11191711)

--- a/Docs/Applications/Sports/BikeModel.md
+++ b/Docs/Applications/Sports/BikeModel.md
@@ -8,7 +8,7 @@ gallery_image: "/Applications/images/BikeModel-FullBody.webp"
 # Bike Model
 
 ````{sidebar} **Example**
-<img src="/Applications/images/BikeModel.webp" width="70%" align="center">
+<img src="/Applications/images/BikeModel-FullBody.webp" width="70%" align="center">
 ````
 
 

--- a/Docs/Applications/Sports/BikeModel.md
+++ b/Docs/Applications/Sports/BikeModel.md
@@ -4,7 +4,7 @@ gallery_image: "/Applications/images/BikeModel-FullBody.webp"
 ---
 
 (sphx_glr_auto_examples_Sports_plot_BikeModel.py)=
-
+(example_bikemodel)=
 # Bike Model
 
 ````{sidebar} **Example**


### PR DESCRIPTION
This PR adds a switch to exclude the thoracic support in full body bike model where the thorax is supported by the arms. Changelog entry is added and the image on the bike model documentation page is updated