### PR TITLE
feat: Implemented HumanGround residuals with rotvector/AngVel=On

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+(ammr-3.0.5-changelog)=
+## AMMR 3.0.5 (2024-??-??)
+
+### 🔧 Changed:
+* Changed the Human-Ground residual implmentation in the MoCap models to use rotatinal measures configured
+  for measuring angual velocities. This change should make the resiuals more robust, and the residual output
+  easier to interpret geometrically. Otherwise, this should not change results. 
+
+
 (ammr-3.0.4-changelog)=
 ## AMMR 3.0.4 (2024-07-02)
 [![Zenodo link](https://zenodo.org/badge/DOI/10.5281/zenodo.12592455.svg)](https://doi.org/10.5281/zenodo.12592455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 ## AMMR 3.0.5 (2024-??-??)
 
 ### 🔧 Changed:
-* Changed the Human-Ground residual implmentation in the MoCap models to use rotatinal measures configured
-  for measuring angual velocities. This change should make the resiuals more robust, and the residual output
-  easier to interpret geometrically. Otherwise, this should not change results. 
+* Changed the Human-Ground residual implmentation in the MoCap models to use
+  rotatinal measures configured for measuring angual velocities. This change
+  should make the resiuals more robust, and the residual output easier to
+  interpret geometrically. Otherwise, this should not change results. 
+* The Force plates are no longer included in the parameter identification study.
+  It wasn't needed, and this change may speed up the parameter identification
+  process slightly.
 
 
 (ammr-3.0.4-changelog)=

--- a/Tests/AnyMocap/Test_Plug-in-gait_simple_fullbody_ParamID.any
+++ b/Tests/AnyMocap/Test_Plug-in-gait_simple_fullbody_ParamID.any
@@ -13,7 +13,7 @@
 #path TEMP_PATH "Output/"
 
 
-#define N_STEP_PARAM_OPT 30
+#define N_STEP_PARAM_OPT 20
 
 #include "<MOCAP_PATH_MAINFILE>"
 

--- a/Tools/AnyMocap/HumanGroundResiduals.any
+++ b/Tools/AnyMocap/HumanGroundResiduals.any
@@ -9,12 +9,15 @@
   /// text books. This residual force is added to the Pelvis segment
   AnyReacForce HumanGroundResiduals = 
   {
-    AnyKinMeasure& PelvisPosX = ..BodyModel.Interface.Trunk.PelvisPosX;
-    AnyKinMeasure& PelvisPosY = ..BodyModel.Interface.Trunk.PelvisPosY;
-    AnyKinMeasure& PelvisPosZ = ..BodyModel.Interface.Trunk.PelvisPosZ;
-    AnyKinMeasure& PelvisRotX = ..BodyModel.Interface.Trunk.PelvisRotX;
-    AnyKinMeasure& PelvisRotY = ..BodyModel.Interface.Trunk.PelvisRotY;
-    AnyKinMeasure& PelvisRotZ = ..BodyModel.Interface.Trunk.PelvisRotZ;
+    AnyKinLinear Lin = { 
+      Ref = 0; 
+      AnyRefFrame& ref0 = ...BodyModel.Trunk.SegmentsLumbar.PelvisSeg;
+    };
+    AnyKinRotational Rot = {
+      Type = RotVector;
+               AngVelOnOff = On;
+      AnyRefFrame& ref0 = ...BodyModel.Trunk.SegmentsLumbar.PelvisSeg;
+    };
   };
   #endif
   
@@ -24,8 +27,15 @@
   /// text books. This residual force is added to the Trunk segment
   AnyReacForce HumanGroundResiduals = 
   {
-    AnyKinLinear Lin = { Ref = 0; AnyRefFrame& ref = ...BodyModel.Trunk.SegmentsThorax.ThoraxSeg; };
-    AnyKinRotational Rot = { Type = RotAxesAngles; AnyRefFrame& ref = ...BodyModel.Trunk.SegmentsThorax.ThoraxSeg; };
+    AnyKinLinear Lin = { 
+      Ref = 0; 
+      AnyRefFrame& ref0 = ...BodyModel.Trunk.SegmentsThorax.ThoraxSeg;
+    };
+    AnyKinRotational Rot = {
+      Type = RotVector;
+      AngVelOnOff = On;
+      AnyRefFrame& ref0 = ...BodyModel.Trunk.SegmentsThorax.ThoraxSeg;
+    };
   };
   #endif
   

--- a/Tools/AnyMocap/KinematicStudyForParameterIdentification.any
+++ b/Tools/AnyMocap/KinematicStudyForParameterIdentification.any
@@ -17,7 +17,7 @@ AnyKinStudy KinematicStudyForParameterIdentification =
   AnyComponentDefinition obj = {};
   Gravity = {0,0,0};/// Not relevant for AnyKinStudy
   AnyFolder& BodyModel = Main.HumanModel.BodyModelWithoutMuscles ; 
-  AnyFolder &EnvironmentModel = Main.EnvironmentModel;
+//  AnyFolder &EnvironmentModel = Main.EnvironmentModel;
   
   AnyFolder ModelEnvironmentConnection = 
   {

--- a/Tools/GRFPrediction/WeakResiduals.any
+++ b/Tools/GRFPrediction/WeakResiduals.any
@@ -38,7 +38,8 @@ AnyFolder HumanGroundResiduals = {
     };   
     AnyKinRotational RotationalPelvis ={
         AnySeg &ref2 = ..PelvisSegment;
-        Type=RotAxesAngles;
+        Type=RotVector;
+        AngVelOnOff = On; 
     };
   };
   


### PR DESCRIPTION
This PR updates the rotational measures used for the residuals to caculate the angular velocities as output.

This should give a more robust measure (less prone to +/- 2pi flipping) to apply the residual forces to. 