### PR TITLE
fix: Mocap marker arrows Visible switch fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1751,7 +1751,7 @@ the driver values are updated.
 - The model is versioned TLEM 2.1, to indicate the number of changes and
   correction which has been added in the process. The changes and updates to the
   TLEM2 dataset was done in the [Life Long
-  Joints](https://web.archive.org/web/20230323035759/https://lifelongjoints.eu/)
+  Joints](https://web.archive.org/web/20230108081423/https://lifelongjoints.eu/)
   EU research project (paper submitted for publication).
 
 - The most important changes to the TLEM 2 dataset include the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 (ammr-3.0.5-changelog)=
 ## AMMR 3.0.5 (2024-??-??)
 
+### 🩹 Fixed:
+* Fixed an issue that prevented switching off drawing of marker arrows in CreateMarkerDriverClass in MoCap models. Updated the search string
+  used in `Main.ModelSetup.Views.All_MarkerArrows.Objects` to correctly pick up the arrow drawing objects.
+
 ### 🔧 Changed:
 * Changed the Human-Ground residual implmentation in the MoCap models to use
   rotatinal measures configured for measuring angual velocities. This change

--- a/Docs/body/leg_tlem2_model.md
+++ b/Docs/body/leg_tlem2_model.md
@@ -48,7 +48,7 @@ it easier to implement Force Dependent Kinematics on joint movements ({doc}`see
 tutorial <tutorials:ForceDependentKinematics/index>`)
 
 The model was refined during the [Life Long Joints
-project](https://web.archive.org/web/20230323035759/https://lifelongjoints.eu/) where its anatomical fidelity and joint
+project](https://web.archive.org/web/20230108081423/https://lifelongjoints.eu/) where its anatomical fidelity and joint
 force prediction accuracy were improved by De Pieri et al. [^cite_dlgr17], 
 mainly, by implementing better a wrapping surfaces for the muscles ([TLEM
 v2.1](#TLEM2-v2.1)). 

--- a/Tools/AnyMocap/DrawVector.any
+++ b/Tools/AnyMocap/DrawVector.any
@@ -9,7 +9,11 @@ Line = {
 };
 Opacity = iffun(bool(sum(...Driver.WeightPos)), 1.0, 0.2);
 #var AnyVar size=.Arrows.size;
+#ifdef _MOCAP_HIDE_MARKER_ARROWS_
+#var Visible = Off;
+#else
 #var Visible = On;
+#endif
 Line.Style = Line3DStyleFull;
 Line.Thickness=0.1*size;
 Line.End.Thickness =0.3*size;             

--- a/Tools/AnyMocap/DrawVector.any
+++ b/Tools/AnyMocap/DrawVector.any
@@ -9,14 +9,12 @@ Line = {
 };
 Opacity = iffun(bool(sum(...Driver.WeightPos)), 1.0, 0.2);
 #var AnyVar size=.Arrows.size;
-#ifdef _MOCAP_HIDE_MARKER_ARROWS_
-#var Visible = Off;
-#endif
+#var Visible = On;
 Line.Style = Line3DStyleFull;
 Line.Thickness=0.1*size;
 Line.End.Thickness =0.3*size;             
 Line.End.Length =0.4*size;             
-Line.End.Style=Line3DCapStyleArrow        ;
+Line.End.Style=Line3DCapStyleArrow;
 PointAway = On;
 GlobalCoord=Off;
 DrawCoord=On;

--- a/Tools/AnyMocap/ModelViews.any
+++ b/Tools/AnyMocap/ModelViews.any
@@ -18,7 +18,7 @@ Views = {
         Objects = ObjSearchRecursive("Main.ModelSetup.MocapDrivers","*", "AnyDrawObject");
       };
       AnyDrawGroup All_MarkerArrows = {
-        Objects = ObjSearchRecursive("Main.HumanModel.BodyModel","Arrows.*", "AnyDrawVector");
+        Objects = ObjSearchRecursive("Main.HumanModel.BodyModel","Arrow*", "AnyDrawVector");
       };
       AnyDrawGroup All_Human ={
         Objects = set_difference( ObjSearchRecursive("Main.HumanModel","*", "AnyDrawObject"), .All_Muscles.Objects, .All_MarkerArrows.Objects, .ForceRelatedObjects.Objects);


### PR DESCRIPTION
The CreateMarkerDriverClass template is not able to switch off drawing of arrows of the markers. This PR fixes it. Additionally, the search string for marker arrows has been updated in Main.ModelSetup.Views.DrawGroups.All_MarkerArrows.Objects. It was not picking up the arrow drawing previously.