### PR TITLE
feat: Class template seg com node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ## AMMR 3.0.5 (2024-??-??)
 
 ### ➕ Added:
-* Added a small class template, [`CreateCoMRefNode`](#Utilities.centre-of-mass.createcomrefnode.createcomrefnode),
-  that can be used to create a reference node at the centre of mass of a segment with its axes aligned with
+* Added a small class template, [`CreateCoMRefNode`](#Utilities.center-of-mass.createcomrefnode.createcomrefnode),
+  that can be used to create a reference node at the center of mass of a segment with its axes aligned with
   the principal axes of inertia of the segment.
 
 ### 🩹 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 (ammr-3.0.5-changelog)=
 ## AMMR 3.0.5 (2024-??-??)
 
+### ➕ Added:
+* Added a small class template, [`CreateCoMRefNode`](#Utilities.centre-of-mass.createcomrefnode.createcomrefnode),
+  that can be used to create a reference node at the centre of mass of a segment with its axes aligned with
+  the principal axes of inertia of the segment.
+
 ### 🩹 Fixed:
 * Fixed an issue that prevented switching off drawing of marker arrows in CreateMarkerDriverClass in MoCap models. Updated the search string
   used in `Main.ModelSetup.Views.All_MarkerArrows.Objects` to correctly pick up the arrow drawing objects.

--- a/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
+++ b/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
@@ -31,8 +31,11 @@ To use the class template import the file:
 //:::
 //
 #class_template CreateCoMRefNode (__CLASS__ = AnyRefNode){
+  /// Jmatrix about the centre of mass
   AnyMat33 JMatCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
+  /// Matrix with eigen vectors and eigen values from the Jmatrix about centre of mass
   AnyMatrix JMatEV = LAPACK_syevd(JMatCoM,"V","V");
+  /// Eigen vectors of the Jmatrix about the centre of mass
   AnyFloat EigenVectors = {JMatEV[0],JMatEV[1],JMatEV[2]};
   
   // sRel

--- a/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
+++ b/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
@@ -14,7 +14,7 @@ To use the class template import the file:
 
 
 // Creates a reference node at the centre of mass of the segment. The orientation of the reference
-// node is determined from the principal axes of inertia, which are determined from the Jmatrix of.
+// node is determined from the principal axes of inertia, which are determined from the Jmatrix of
 // the segment. This class template must be used inside the scope of AnySegment.
 //
 // In the example below a reference node is created inside a segment.
@@ -30,8 +30,7 @@ To use the class template import the file:
 // };
 //:::
 //
-#class_template CreateCoMRefNode (__CLASS__ = AnyRefNode,){
-  
+#class_template CreateCoMRefNode (__CLASS__ = AnyRefNode){
   AnyMat33 JMatCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
   AnyMatrix JMatEV = LAPACK_syevd(JMatCoM,"V","V");
   AnyFloat EigenVectors = {JMatEV[0],JMatEV[1],JMatEV[2]};

--- a/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
+++ b/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
@@ -1,9 +1,9 @@
 /*
 ---
 group: Utilities
-topic: Centre of mass
+topic: Center of mass
 descr: |
-  Class template to create a reference node at the centre of mass of a segment
+  Class template to create a reference node at the center of mass of a segment
   with its axis aligned with the principal axes of inertia. 
 ---
 
@@ -13,7 +13,7 @@ To use the class template import the file:
 */
 
 
-// Creates a reference node at the centre of mass of the segment. The orientation of the reference
+// Creates a reference node at the center of mass of the segment. The orientation of the reference
 // node is determined from the principal axes of inertia, which are determined from the Jmatrix of
 // the segment. This class template must be used inside the scope of AnySegment.
 //
@@ -31,11 +31,11 @@ To use the class template import the file:
 //:::
 //
 #class_template CreateCoMRefNode (__CLASS__ = AnyRefNode){
-  /// Jmatrix about the centre of mass
+  /// Jmatrix about the center of mass
   AnyMat33 JMatrixCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
-  /// Matrix with eigen vectors and eigen values from the Jmatrix about centre of mass
+  /// Matrix with eigen vectors and eigen values from the Jmatrix about center of mass
   AnyMatrix JMatrixEV = LAPACK_syevd(JMatrixCoM,"V","V");
-  /// Eigen vectors of the Jmatrix about the centre of mass
+  /// Eigen vectors of the Jmatrix about the center of mass
   AnyFloat EigenVectors = {JMatrixEV[0],JMatrixEV[1],JMatrixEV[2]};
   
   // sRel

--- a/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
+++ b/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
@@ -1,0 +1,58 @@
+/*
+---
+group: Utilities
+topic: Centre of mass
+descr: |
+  Class template to create a reference node at the centre of mass of a segment
+  with its axis aligned with the principal axes of inertia. 
+---
+
+To use the class template import the file:
+#include "<ANYBODY_PATH_MODELUTILS>/SegmentCoM/CreateCoMRefNode.any"
+
+*/
+
+
+// Creates a reference node at the centre of mass of the segment. The orientation of the reference
+// node is determined from the principal axes of inertia, which are determined from the Jmatrix of.
+// the segment. This class template must be used inside the scope of AnySegment.
+//
+// In the example below a reference node is created inside a segment.
+//
+// :::{rubric} Example
+// :::
+//
+// :::{code-block} AnyScriptDoc
+// AnySeg MySegment = {
+//   CreateCoMRefNode CoMNode () = {
+//     viewRefFrame.Visible = On;
+//   };
+// };
+//:::
+//
+#class_template CreateCoMRefNode (__CLASS__ = AnyRefNode,){
+  
+  AnyMat33 JMatCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
+  AnyMatrix JMatEV = LAPACK_syevd(JMatCoM,"V","V");
+  AnyFloat EigenVectors = {JMatEV[0],JMatEV[1],JMatEV[2]};
+  
+  // sRel
+  /// Relative position of the reference node in the segmental frame. This defaults to
+  /// segment sCoM.
+  #var sRel = .sCoM;
+  // ARel 
+  /// Relative orientation of the reference node in the segmental frame. This defaults to
+  /// be aligned with the principal axes of inertia.
+  #var ARel = {EigenVectors[0],EigenVectors[1],cross(EigenVectors[0],EigenVectors[1])}';
+  viewRefFrame = {
+    //viewRefFrame.Visible = Off;
+    /// Switch to view the reference node.
+    #var Visible = Off;
+    //viewRefFrame.ScaleXYZ = 0.5*{1,1,1};
+    /// Size of the drawing of the reference node.
+    #var ScaleXYZ = 0.5*{1,1,1};
+    // viewRefFrame.RGB = {0.8,0.2,0.2};
+    /// Color of the drawing of the reference node.
+    #var RGB = {0.8,0.2,0.2};
+  };
+};

--- a/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
+++ b/Tools/ModelUtilities/SegmentCoM/CreateCoMRefNode.any
@@ -32,11 +32,11 @@ To use the class template import the file:
 //
 #class_template CreateCoMRefNode (__CLASS__ = AnyRefNode){
   /// Jmatrix about the centre of mass
-  AnyMat33 JMatCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
+  AnyMat33 JMatrixCoM = .Jmatrix + .Mass*skewmat3d(.sCoM)*skewmat3d(.sCoM);
   /// Matrix with eigen vectors and eigen values from the Jmatrix about centre of mass
-  AnyMatrix JMatEV = LAPACK_syevd(JMatCoM,"V","V");
+  AnyMatrix JMatrixEV = LAPACK_syevd(JMatrixCoM,"V","V");
   /// Eigen vectors of the Jmatrix about the centre of mass
-  AnyFloat EigenVectors = {JMatEV[0],JMatEV[1],JMatEV[2]};
+  AnyFloat EigenVectors = {JMatrixEV[0],JMatrixEV[1],JMatrixEV[2]};
   
   // sRel
   /// Relative position of the reference node in the segmental frame. This defaults to


### PR DESCRIPTION
This PR adds a class template that can generate a reference node at the centre of mass of a segment with its axes aligned with the principal axes of inertia