### PR TITLE
fix: Bug fix free posture pelvis ground driver

### DIFF
--- a/Application/Examples/FreePosture/Model/ConstantDrivers/TrunkDrivers.any
+++ b/Application/Examples/FreePosture/Model/ConstantDrivers/TrunkDrivers.any
@@ -19,9 +19,9 @@
       .JntPos.PelvisPosX,
       .JntPos.PelvisPosY,
       .JntPos.PelvisPosZ,
-      pi/180*.JntPos.PelvisRotZ,
+      pi/180*.JntPos.PelvisRotX,
       pi/180*.JntPos.PelvisRotY,
-      pi/180*.JntPos.PelvisRotX
+      pi/180*.JntPos.PelvisRotZ
     };
     DriverVel={
       .JntVel.PelvisPosX,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### 🩹 Fixed:
 * Fixed an issue that prevented switching off drawing of marker arrows in CreateMarkerDriverClass in MoCap models. Updated the search string
   used in `Main.ModelSetup.Views.All_MarkerArrows.Objects` to correctly pick up the arrow drawing objects.
+* Fixed an issue in the PelvisGround rotation drivers in the {ref}`Free Posture Static example<example_freeposture>`. The X and Z rotation drivers 
+  were mixed up.
 
 ### 🔧 Changed:
 * Changed the Human-Ground residual implmentation in the MoCap models to use

--- a/Docs/Applications/Daily-activities-and-ergonomics/FreePosture.md
+++ b/Docs/Applications/Daily-activities-and-ergonomics/FreePosture.md
@@ -4,7 +4,7 @@ gallery_image: "/Applications/images/FreePostureFullBodyShoulderRhythmStatic.web
 ---
 
 (sphx-glr-auto-examples-adls-and-ergonomics-plot-freeposture-py)=
-
+(example_freeposture)=
 # Free posture Models
 
 


### PR DESCRIPTION
The pelvis ground driver in the free posture static model had the rotation drivers in X and Z mixed up. This is fixed in this PR. Changelog is added.