### PR TITLE
fix: Updated insertions and origin for Gluteus medius

### DIFF
--- a/Body/AAUHuman/LegTLEM/Mus.any
+++ b/Body/AAUHuman/LegTLEM/Mus.any
@@ -1144,120 +1144,87 @@ AnyMuscleViaPoint GluteusMinimusPosterior1 = {
 AnyMuscleViaPoint GluteusMediusAnterior1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior1Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior1Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior2Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior2Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior3Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior3Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior4Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior4Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior5Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior5Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior6Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior6Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior1Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior1Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior2Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior2Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior3Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior3Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior4Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior4Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior5Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior5Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior6Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior6Node;
+  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
-#ifndef GLUTEUS_MEDIUS_INSERTION
-#define GLUTEUS_MEDIUS_INSERTION _DEFAULT_
-#endif
-#if (GLUTEUS_MEDIUS_INSERTION == _DEFAULT_) | (GLUTEUS_MEDIUS_INSERTION == _NEW_INSERTION_POINTS_)
-GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;};
-GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;};
-GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;};
-GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;};
-GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;};
-GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;};
-GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;};
-GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;};
-GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;};
-GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;};
-GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;};
-#endif
-#if GLUTEUS_MEDIUS_INSERTION == _INVERTED_
-GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;};
-GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;};
-GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;};
-GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;};
-GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;};
-GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;};
-GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;};
-GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;};
-GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;};
-GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;};
-GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;};
-#endif
-#if GLUTEUS_MEDIUS_INSERTION == _CENTERED_
-GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
-#endif
 
 
 AnyMuscleShortestPath GluteusMaximusSuperior1 = {

--- a/Body/AAUHuman/LegTLEM/Mus.any
+++ b/Body/AAUHuman/LegTLEM/Mus.any
@@ -1216,7 +1216,7 @@ AnyMuscleViaPoint GluteusMediusPosterior6 = {
 #ifndef GLUTEUS_MEDIUS_INSERTION
 #define GLUTEUS_MEDIUS_INSERTION _DEFAULT_
 #endif
-#if GLUTEUS_MEDIUS_INSERTION == _DEFAULT_
+#if (GLUTEUS_MEDIUS_INSERTION == _DEFAULT_) | (GLUTEUS_MEDIUS_INSERTION == _NEW_INSERTION_POINTS_)
 GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
 GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;};
 GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;};

--- a/Body/AAUHuman/LegTLEM/Mus.any
+++ b/Body/AAUHuman/LegTLEM/Mus.any
@@ -1144,87 +1144,120 @@ AnyMuscleViaPoint GluteusMinimusPosterior1 = {
 AnyMuscleViaPoint GluteusMediusAnterior1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior1Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior1Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior2Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior2Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior3Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior3Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior4Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior4Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior5Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior5Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusAnterior6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusAnterior6Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusAnterior6Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior1Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior1Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior2Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior2Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior3Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior3Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior4Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior4Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior5Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior5Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint GluteusMediusPosterior6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.GluteusMediusPosterior6Par;
   AnyRefNode &Org = ..Seg.Pelvis.Muscles.GluteusMediusPosterior6Node;
-  AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;
   viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
 };
 
+#ifndef GLUTEUS_MEDIUS_INSERTION
+#define GLUTEUS_MEDIUS_INSERTION _DEFAULT_
+#endif
+#if GLUTEUS_MEDIUS_INSERTION == _DEFAULT_
+GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;};
+GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;};
+GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;};
+GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;};
+GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;};
+GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;};
+GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;};
+GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;};
+GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;};
+GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;};
+GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;};
+#endif
+#if GLUTEUS_MEDIUS_INSERTION == _INVERTED_
+GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior1Node;};
+GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior2Node;};
+GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior3Node;};
+GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior4Node;};
+GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior5Node;};
+GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusPosterior6Node;};
+GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior2Node;};
+GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior3Node;};
+GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior4Node;};
+GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior5Node;};
+GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior6Node;};
+#endif
+#if GLUTEUS_MEDIUS_INSERTION == _CENTERED_
+GluteusMediusAnterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusAnterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior1 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior2 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior3 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior4 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior5 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+GluteusMediusPosterior6 = {AnyRefNode &Ins = ..Seg.Thigh.GluteusMediusAnterior1Node;};
+#endif
 
 
 AnyMuscleShortestPath GluteusMaximusSuperior1 = {

--- a/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
+++ b/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
@@ -339,6 +339,10 @@ AnyFolder ModelParameters = {
     AnyVec3 GluteusMaximusSuperior6Node = {-0.0167,  0.30088,  0.052980}*.TF';
     
     
+    #ifndef GLUTEUS_MEDIUS_INSERTION
+    #define GLUTEUS_MEDIUS_INSERTION _DEFAULT_
+    #endif
+    #if GLUTEUS_MEDIUS_INSERTION != _NEW_INSERTION_POINTS_
     AnyVec3 GluteusMediusAnterior1Node = {-0.00879, 0.34432, 0.06574}*.TF';
     AnyVec3 GluteusMediusAnterior2Node = {-0.00287, 0.33756, 0.06839}*.TF';
     AnyVec3 GluteusMediusAnterior3Node = {0.00318, 0.3339, 0.07064}*.TF';
@@ -355,6 +359,24 @@ AnyFolder ModelParameters = {
     AnyVec3 GluteusMediusPosterior5Node = {-0.01579,0.35539,0.05894}*.TF';
     AnyVec3 GluteusMediusPosterior6Node = {-0.01977,0.35915,0.05206}*.TF';
     
+    #else
+    // GLUTEUS_MEDIUS_INSERTION == _NEW_INSERTION_POINTS_
+    AnyVec3 GluteusMediusAnterior1Node = {-0.0235964,0.359021,0.0471878}*.TF';
+    AnyVec3 GluteusMediusAnterior2Node = {-0.0220794,0.354483,0.0548045}*.TF';
+    AnyVec3 GluteusMediusAnterior3Node = {-0.0179342,0.351566,0.060473}*.TF';
+    AnyVec3 GluteusMediusAnterior4Node = {-0.0126233,0.346893,0.0640114}*.TF';
+    AnyVec3 GluteusMediusAnterior5Node = {-0.0055407,0.342186,0.0669147}*.TF';
+    AnyVec3 GluteusMediusAnterior6Node = {0.00107288,0.33868,0.0678163}*.TF';
+
+        
+    // GluteusMediusPosterior, Area using 6 elements
+    AnyVec3 GluteusMediusPosterior1Node = {-0.0184438,0.361704,0.0504105}*.TF';
+    AnyVec3 GluteusMediusPosterior2Node = {-0.0120976,0.362576,0.053858}*.TF';
+    AnyVec3 GluteusMediusPosterior3Node = {-0.0061009,0.36184,0.0582055}*.TF';
+    AnyVec3 GluteusMediusPosterior4Node = {-0.000400744,0.358869,0.0601335}*.TF';
+    AnyVec3 GluteusMediusPosterior5Node = {0.00477651,0.353151,0.0622942}*.TF';
+    AnyVec3 GluteusMediusPosterior6Node = {0.00548003,0.346231,0.0646099}*.TF';
+    #endif
     
     // GluteusMinimusAnterior
     AnyVec3 GluteusMinimusPosterior1Node  = {0.01656,0.32615,0.05660}*.TF';

--- a/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
+++ b/Body/AAUHuman/LegTLEM/TLEM2.2/ModelParameters.any
@@ -122,10 +122,10 @@ AnyFolder ModelParameters = {
     
     // GluteusMediusPosterior, Area using 4 elements
     AnyVec3 GluteusMediusPosterior6Node = {-0.05382,0.05809,-0.01627}*.TF' - FrameOffset;
-    AnyVec3 GluteusMediusPosterior5Node = {-0.06482,0.1139,-0.01827}*.TF' - FrameOffset;
-    AnyVec3 GluteusMediusPosterior4Node = {-0.06054, 0.12789, -0.0075}*.TF' - FrameOffset;
-    AnyVec3 GluteusMediusPosterior3Node = {-0.05385,  0.13065,  0.00905}*.TF' - FrameOffset;
-    AnyVec3 GluteusMediusPosterior2Node = {-0.03916, 0.12701, 0.0246}*.TF' - FrameOffset;
+    AnyVec3 GluteusMediusPosterior5Node = {-0.07232 ,  0.085995, -0.02277 }*.TF' - FrameOffset;
+    AnyVec3 GluteusMediusPosterior4Node = {-0.07282,  0.1139 , -0.01977}*.TF' - FrameOffset;
+    AnyVec3 GluteusMediusPosterior3Node = {-0.06054,  0.12789, -0.0066}*.TF' - FrameOffset;
+    AnyVec3 GluteusMediusPosterior2Node = {-0.046305,  0.12883 ,  0.014825}*.TF' - FrameOffset;
     AnyVec3 GluteusMediusPosterior1Node = {-0.03122, 0.12208, 0.03577}*.TF' - FrameOffset;
     
     // GluteusMinimusAnterior, Area using 1 elements
@@ -339,28 +339,6 @@ AnyFolder ModelParameters = {
     AnyVec3 GluteusMaximusSuperior6Node = {-0.0167,  0.30088,  0.052980}*.TF';
     
     
-    #ifndef GLUTEUS_MEDIUS_INSERTION
-    #define GLUTEUS_MEDIUS_INSERTION _DEFAULT_
-    #endif
-    #if GLUTEUS_MEDIUS_INSERTION != _NEW_INSERTION_POINTS_
-    AnyVec3 GluteusMediusAnterior1Node = {-0.00879, 0.34432, 0.06574}*.TF';
-    AnyVec3 GluteusMediusAnterior2Node = {-0.00287, 0.33756, 0.06839}*.TF';
-    AnyVec3 GluteusMediusAnterior3Node = {0.00318, 0.3339, 0.07064}*.TF';
-    AnyVec3 GluteusMediusAnterior4Node = {0.00679, 0.33198, 0.07024}*.TF';
-    AnyVec3 GluteusMediusAnterior5Node = {0.01037, 0.33158, 0.06799}*.TF';
-    AnyVec3 GluteusMediusAnterior6Node = {0.01237, 0.33058, 0.06649}*.TF';
-
-        
-    // GluteusMediusPosterior, Area using 6 elements
-    AnyVec3 GluteusMediusPosterior1Node = {-0.00718,0.35174,0.06344}*.TF';
-    AnyVec3 GluteusMediusPosterior2Node = {-0.01142,0.35907,0.05855}*.TF';
-    AnyVec3 GluteusMediusPosterior3Node = {-0.01014,0.34942,0.06367}*.TF';
-    AnyVec3 GluteusMediusPosterior4Node = {-0.01664,0.36185,0.05178}*.TF';
-    AnyVec3 GluteusMediusPosterior5Node = {-0.01579,0.35539,0.05894}*.TF';
-    AnyVec3 GluteusMediusPosterior6Node = {-0.01977,0.35915,0.05206}*.TF';
-    
-    #else
-    // GLUTEUS_MEDIUS_INSERTION == _NEW_INSERTION_POINTS_
     AnyVec3 GluteusMediusAnterior1Node = {-0.0235964,0.359021,0.0471878}*.TF';
     AnyVec3 GluteusMediusAnterior2Node = {-0.0220794,0.354483,0.0548045}*.TF';
     AnyVec3 GluteusMediusAnterior3Node = {-0.0179342,0.351566,0.060473}*.TF';
@@ -376,7 +354,6 @@ AnyFolder ModelParameters = {
     AnyVec3 GluteusMediusPosterior4Node = {-0.000400744,0.358869,0.0601335}*.TF';
     AnyVec3 GluteusMediusPosterior5Node = {0.00477651,0.353151,0.0622942}*.TF';
     AnyVec3 GluteusMediusPosterior6Node = {0.00548003,0.346231,0.0646099}*.TF';
-    #endif
     
     // GluteusMinimusAnterior
     AnyVec3 GluteusMinimusPosterior1Node  = {0.01656,0.32615,0.05660}*.TF';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 
 ### 🔧 Changed:
 * Updated the Gluteus Medius insertions and origin points, to ensure the muscles
-  has correct moment arm for external rotation in certain postures. The
-  posterior gluteus medius now twist inside the anterior part and attaches more
+  have correct moment arm for external rotation in certain postures. The
+  posterior gluteus medius now twist inside the anterior part and attach more
   anteriorly on the femural trochanter.
 * Changed the Human-Ground residual implmentation in the MoCap models to use
   rotatinal measures configured for measuring angual velocities. This change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   were mixed up.
 
 ### 🔧 Changed:
+* Updated the Gluteus Medius insertions and origin points, to ensure the muscles
+  has correct moment arm for external rotation in certain postures. The
+  posterior gluteus medius now twist inside the anterior part and attaches more
+  anteriorly on the femural trochanter.
 * Changed the Human-Ground residual implmentation in the MoCap models to use
   rotatinal measures configured for measuring angual velocities. This change
   should make the resiuals more robust, and the residual output easier to


### PR DESCRIPTION
Updated the Gluteus Medius insertions and origin points, to ensure the muscles has correct moment arm for external rotation in certain postures.

@divyaksh-chander identified some postures where gluteus medius failed to provide the necessary external rotation moment. This could be fixed by refining the gluteus medius insertions to better match what we observed from different anatomical dissection videos. The posterior part of gluteus medius twists inside the anterior part and insert more anteriorly on the femoral trochanter. 

Most anatomical text book doesn't show this complexity of the fiber alignment. But some do like for example this one: 

![image](https://github.com/user-attachments/assets/fecc3018-fac8-4273-8c41-5afa7785f904)
(source: https://movewellacademy.com/muscle-minute-tuesday-meet-the-gluteus-medius/)
 
 The following images show before and after this fix: 
 
 
![image](https://github.com/user-attachments/assets/c272ea76-a200-4e0f-99d4-e9e1b4b5770b)

![image](https://github.com/user-attachments/assets/1e3ee091-1c8f-4113-9051-775594bc637b)
 