### PR TITLE
fix: Change wrapping surface from cylinder to ellipsoid for muscles at the wrist #33

### DIFF
--- a/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
+++ b/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
@@ -318,19 +318,11 @@ AnyFolder Radius = {
   AnyFloat WristFlexorEllipsoid_pos = wj_pos + {0.009210971, -0.0003975198, -0.0014};
   AnyFloat WristFlexorEllipsoid_P3_pos = {-0.2158542, -0.01637023, 0.009193912}; // x axis
   AnyFloat WristFlexorEllipsoid_P2_pos = {-0.2250712, -0.006009247, 0.01196824}; // y axis
-  
-  AnyFloat WristFlexorTorus_pos = wj_pos + {0.002939388, 0.001697056, 0.0056};
-  AnyFloat WristFlexorTorus_P3_pos = {-0.2312188, -0.01352852, 0.005638053}; // x axis
-  AnyFloat WristFlexorTorus_P2_pos = {-0.2320511, -0.003305493, 0.01537442}; // y axis
-  
+    
   AnyFloat WristExtensorEllipsoid_pos = wj_pos + {0.001862501, -0.00464016, -0.001};
   AnyFloat WristExtensorEllipsoid_P3_pos = {-0.2232895, -0.02137677, 0.009015211}; // x axis
   AnyFloat WristExtensorEllipsoid_P2_pos = {-0.2314014, -0.009793548, 0.00917386}; // y axis
-  
-  AnyFloat WristExtensorTorus_pos = wj_pos + {0.005157799, 0.003794353, -0.0046};
-  AnyFloat WristExtensorTorus_P3_pos = {-0.2316853, -0.0107118, -0.004416272}; // x axis
-  AnyFloat WristExtensorTorus_P2_pos = {-0.2303107, -0.001234046, 0.005989632}; // y axis
-  
+    
   AnyVec3 correction ={0,-0.005,0.00};
   
   AnyFloat I_Biceps_LH_pos                      = {-0.004634000, 0.01056600, -0.006213000};

--- a/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
+++ b/Body/AAUHuman/Arm/ArmData1.1/ArmModelParameters.any
@@ -315,6 +315,22 @@ AnyFolder Radius = {
   AnyFloat WristFlexorCyl_P3_pos = WristFlexorCyl_pos + {0.0,0.0,-0.0130};
   AnyFloat WristFlexorCyl_P2_pos = WristFlexorCyl_pos + {0.003, 0.025,0.0};
     
+  AnyFloat WristFlexorEllipsoid_pos = wj_pos + {0.009210971, -0.0003975198, -0.0014};
+  AnyFloat WristFlexorEllipsoid_P3_pos = {-0.2158542, -0.01637023, 0.009193912}; // x axis
+  AnyFloat WristFlexorEllipsoid_P2_pos = {-0.2250712, -0.006009247, 0.01196824}; // y axis
+  
+  AnyFloat WristFlexorTorus_pos = wj_pos + {0.002939388, 0.001697056, 0.0056};
+  AnyFloat WristFlexorTorus_P3_pos = {-0.2312188, -0.01352852, 0.005638053}; // x axis
+  AnyFloat WristFlexorTorus_P2_pos = {-0.2320511, -0.003305493, 0.01537442}; // y axis
+  
+  AnyFloat WristExtensorEllipsoid_pos = wj_pos + {0.001862501, -0.00464016, -0.001};
+  AnyFloat WristExtensorEllipsoid_P3_pos = {-0.2232895, -0.02137677, 0.009015211}; // x axis
+  AnyFloat WristExtensorEllipsoid_P2_pos = {-0.2314014, -0.009793548, 0.00917386}; // y axis
+  
+  AnyFloat WristExtensorTorus_pos = wj_pos + {0.005157799, 0.003794353, -0.0046};
+  AnyFloat WristExtensorTorus_P3_pos = {-0.2316853, -0.0107118, -0.004416272}; // x axis
+  AnyFloat WristExtensorTorus_P2_pos = {-0.2303107, -0.001234046, 0.005989632}; // y axis
+  
   AnyVec3 correction ={0,-0.005,0.00};
   
   AnyFloat I_Biceps_LH_pos                      = {-0.004634000, 0.01056600, -0.006213000};

--- a/Body/AAUHuman/Arm/Muscle.any
+++ b/Body/AAUHuman/Arm/Muscle.any
@@ -21,7 +21,7 @@ AnyMuscleShortestPath  biceps_brachii_caput_breve = {
   AnyMuscleModel &MusMdl = ..MuscleModels.biceps_brachii_caput_breve; 
   AnyRefNode &Org = ..Seg.Scapula.O_biceps_brachii_caput_breve; 
   AnyRefNode &Ins = ..Seg.Radius.I_Biceps_SH ; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 200;  
   AnySurfCylinder &Surf0 =.condylus_hum;
   AnySurfCylinder &Surf3 =.bicepscyl;
@@ -38,7 +38,7 @@ AnyMuscleShortestPath biceps_brachii_caput_longum = {
   AnyRefNode &Via2 = ..Seg.Humerus.sulcus_intertubercularis;
   AnyRefNode &Ins = ..Seg.Radius.I_Biceps_LH;  //this point has been taken from MAYO study
   
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"}; 
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"}; 
   SPLine.StringMesh = 150;    
   AnySurfEllipsoid &Surfgh =.art_gh_humRef;
   AnySurfCylinder &Surf0 =.condylus_hum;
@@ -62,42 +62,42 @@ AnyMuscleViaPoint coracobrachialis_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_1; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint coracobrachialis_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint coracobrachialis_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint coracobrachialis_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_4;
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint coracobrachialis_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint coracobrachialis_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.coracobrachialis_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_coracobrachialis_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_coracobrachialis_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
   #if BM_ARM_DELTOID_WRAPPING == _DELTOID_WRAPPING_RAKE_
@@ -124,7 +124,7 @@ AnyMuscleShortestPath deltoideus_scapular_part_2 = {
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia2;
   
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_scapular_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine = {
@@ -152,7 +152,7 @@ AnyMuscleShortestPath deltoideus_scapular_part_4 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_scapular_part_4; 
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia4;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_scapular_part_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine = {
@@ -166,7 +166,7 @@ AnyMuscleShortestPath deltoideus_scapular_part_5 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_scapular_part_5; 
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia5;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_scapular_part_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any" };
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any" };
   SPLine.StringMesh = 40;
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine = {
@@ -223,7 +223,7 @@ AnyMuscleShortestPath deltoideus_clavicular_part_3 = {
   AnyRefNode &Org = ..Seg.Clavicula.O_deltoideus_clavicular_part_3; 
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia9;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_clavicular_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine.StringMesh = 35;
   SPLine = {
@@ -237,7 +237,7 @@ AnyMuscleShortestPath deltoideus_clavicular_part_4 = {
   AnyRefNode &Org = ..Seg.Clavicula.O_deltoideus_clavicular_part_4; 
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia10;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_clavicular_part_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine = {
@@ -251,7 +251,7 @@ AnyMuscleShortestPath deltoideus_clavicular_part_5 = {
   AnyRefNode &Org = ..Seg.Clavicula.O_deltoideus_clavicular_part_5; 
   AnyRefNode &Via = .ArtificialRake.DeltoidMuscleConnector.DeltoidVia11;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_clavicular_part_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   AnySurfSphere &Surf =.art_tub_minus_tub_majusRef;
   SPLine = {
@@ -282,7 +282,7 @@ AnyMuscleShortestPath deltoideus_posterior_part_1 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_posterior_part_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_posterior_part_1; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
-  SPLine.StringMesh = 30;
+  SPLine.StringMesh = 45;
 
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingPosterior.BASE_FRAME.Wrapping_1.Surf;
   AnyParamSurfAnalytical &Surf2 =..Seg.Scapula.deltoid_cyl.cyl; 
@@ -304,7 +304,7 @@ AnyMuscleShortestPath deltoideus_posterior_part_3 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_posterior_part_3;
   
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_posterior_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
 
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingPosterior.BASE_FRAME.Wrapping_3.Surf;
@@ -329,7 +329,7 @@ AnyMuscleShortestPath deltoideus_posterior_part_2 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_posterior_part_2;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_posterior_part_2; 
   SPLine.StringMesh = 30;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingPosterior.BASE_FRAME.Wrapping_2.Surf;
   AnyParamSurfAnalytical &Surf2 =..Seg.Scapula.deltoid_cyl.cyl;
   SPLine = {         
@@ -347,7 +347,7 @@ AnyMuscleShortestPath deltoideus_posterior_part_4 = {
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_posterior_part_4;
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_posterior_part_4; 
   SPLine.StringMesh = 20;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingPosterior.BASE_FRAME.Wrapping_4.Surf;
   AnyParamSurfAnalytical &Surf2 =..Seg.Scapula.deltoid_cyl.cyl; 
 
@@ -385,7 +385,7 @@ AnyMuscleShortestPath deltoideus_lateral_part_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.deltoideus_lateral_part_3;
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_lateral_part_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_lateral_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
  
  
@@ -406,7 +406,7 @@ AnyMuscleShortestPath deltoideus_lateral_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.deltoideus_lateral_part_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_lateral_part_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_lateral_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingLateral.BASE_FRAME.Wrapping_2.Surf;
   
@@ -424,7 +424,7 @@ AnyMuscleShortestPath deltoideus_lateral_part_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.deltoideus_lateral_part_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_deltoideus_lateral_part_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_lateral_part_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any" };
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any" };
   SPLine.StringMesh = 30;
   
 
@@ -468,7 +468,7 @@ AnyMuscleShortestPath deltoideus_anterior_part_2 = {
   AnyRefNode &Org = ..Seg.Clavicula.O_deltoideus_anterior_part_2; 
   
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_anterior_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
 
   AnyParamSurfAnalytical &Surf =.DeltoidWrappingAnterior.BASE_FRAME.Wrapping_2.Surf;
@@ -486,7 +486,7 @@ AnyMuscleShortestPath deltoideus_anterior_part_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.deltoideus_anterior_part_3; 
   AnyRefNode &Org = ..Seg.Clavicula.O_deltoideus_anterior_part_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_deltoideus_anterior_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
   
   SPLine.StringMesh = 30;
@@ -550,7 +550,7 @@ AnyMuscleShortestPath infraspinatus_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.infraspinatus_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_infraspinatus_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_infraspinatus_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.infraspinatus_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .infraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -560,7 +560,7 @@ AnyMuscleShortestPath infraspinatus_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.infraspinatus_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_infraspinatus_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_infraspinatus_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.infraspinatus_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .infraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -570,7 +570,7 @@ AnyMuscleShortestPath infraspinatus_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.infraspinatus_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_infraspinatus_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_infraspinatus_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.infraspinatus_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .infraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -580,7 +580,7 @@ AnyMuscleShortestPath infraspinatus_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.infraspinatus_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_infraspinatus_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_infraspinatus_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 40;
   AnyParamSurf &Surf =..Seg.Humerus.infraspinatus_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .infraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -590,7 +590,7 @@ AnyMuscleShortestPath infraspinatus_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.infraspinatus_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_infraspinatus_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_infraspinatus_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 40;
   AnyParamSurf &Surf =..Seg.Humerus.infraspinatus_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .infraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -617,7 +617,7 @@ AnyMuscleShortestPath latissimus_dorsi_1 = {
     };         
     InitWrapPosVecArr = {&InitWrapPos};
   }; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};     
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};     
   
 };
 
@@ -632,7 +632,7 @@ AnyMuscleShortestPath latissimus_dorsi_2 = {
   AnyParamSurf &Surf4 = ..Seg.Scapula.Lattisimus_wrap.cyl;
 
   SPLine.InitWrapPosVecArr = .latissimus_dorsi_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};     
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};     
 };
 
 
@@ -647,7 +647,7 @@ AnyMuscleShortestPath latissimus_dorsi_3 = {
   AnyParamSurf &Surf4 = ..Seg.Scapula.Lattisimus_wrap.cyl;
 
   SPLine.InitWrapPosVecArr = .latissimus_dorsi_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};     
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};     
 };
 
 AnyMuscleShortestPath latissimus_dorsi_4 = {
@@ -661,7 +661,7 @@ AnyMuscleShortestPath latissimus_dorsi_4 = {
   AnyParamSurf &Surf4 = ..Seg.Scapula.Lattisimus_wrap.cyl;
 
   SPLine.InitWrapPosVecArr = .latissimus_dorsi_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};     
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};     
 };
 
 AnyMuscleShortestPath latissimus_dorsi_5 = {
@@ -675,7 +675,7 @@ AnyMuscleShortestPath latissimus_dorsi_5 = {
   AnyParamSurf &Surf4 = ..Seg.Scapula.Lattisimus_wrap.cyl;
 
   SPLine.InitWrapPosVecArr = .latissimus_dorsi_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};     
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};     
 };
 
 AnyMuscleShortestPath latissimus_dorsi_6 = {
@@ -776,28 +776,28 @@ AnyMuscleShortestPath latissimus_dorsi_11 = {
 //  AnyMuscleModel &MusMdl = ..MuscleModels.levator_scapulae_1; 
 //  AnyRefNode &Org = ..C1SegRef.O_levator_scapulae_1; 
 //  AnyRefNode &Ins = ..Seg.Scapula.I_levator_scapulae_1; 
-//  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+//  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 //};
 //
 //AnyMuscleViaPoint levator_scapulae_2 = {
 //  AnyMuscleModel &MusMdl = ..MuscleModels.levator_scapulae_2; 
 //  AnyRefNode &Org = ..C2SegRef.O_levator_scapulae_2; 
 //  AnyRefNode &Ins = ..Seg.Scapula.I_levator_scapulae_2; 
-//  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+//  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 //};
 //
 //AnyMuscleViaPoint levator_scapulae_3 = {
 //  AnyMuscleModel &MusMdl = ..MuscleModels.levator_scapulae_3; 
 //  AnyRefNode &Org = ..C3SegRef.O_levator_scapulae_3; 
 //  AnyRefNode &Ins = ..Seg.Scapula.I_levator_scapulae_3; 
-//  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+//  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 //};
 //
 //AnyMuscleViaPoint levator_scapulae_4 ={
 //  AnyMuscleModel &MusMdl = ..MuscleModels.levator_scapulae_4; 
 //  AnyRefNode &Org = ..C4SegRef.O_levator_scapulae_4 ;
 //  AnyRefNode &Ins = ..Seg.Scapula.I_levator_scapulae_4 ;
-//  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+//  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 //};
 
 
@@ -813,7 +813,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_1 = {
     };         
     InitWrapPosVecArr = {&InitWrapPos};
   };  
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};   
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};   
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_2 = {
@@ -828,7 +828,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_2 = {
     };         
     InitWrapPosVecArr = {&InitWrapPos};
   };  
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};   
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};   
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_3 = {
@@ -843,7 +843,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_3 = {
     };         
     InitWrapPosVecArr = {&InitWrapPos};
   };  
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};   
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};   
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_4 = {
@@ -853,7 +853,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_4 = {
   SPLine.StringMesh = 40;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};      
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};      
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_5 = {
@@ -863,7 +863,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_5 = {
   SPLine.StringMesh = 40;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};      
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};      
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_6 = {
@@ -873,7 +873,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_6 = {
   SPLine.StringMesh = 40;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};      
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};      
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_7 = {
@@ -883,7 +883,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_7 = {
   SPLine.StringMesh = 40;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};       
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};       
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_8 = {
@@ -893,7 +893,7 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_8 = {
   SPLine.StringMesh = 40;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_1.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};       
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};       
 };
 
 AnyMuscleShortestPath pectoralis_major_thoracic_part_9 = {
@@ -924,14 +924,14 @@ AnyMuscleShortestPath pectoralis_major_thoracic_part_10 = {
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   AnyParamSurf& Surf1 =.Pectoralis_minor2_cyl.Cylinder.Segment.node1.Surf;
   SPLine.InitWrapPosVecArr = .pectoralis_major_thoracic_part_9.SPLine.InitWrapPosVecArr;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};      
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};      
 };
 ////
 AnyMuscleShortestPath pectoralis_major_clavicular_part_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_major_clavicular_part_1; 
   AnyRefNode &Org = ..Seg.Clavicula.O_pectoralis_major_clavicular_part_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_pectoralis_major_clavicular_part_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 60;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   AnyParamSurf& Surf3 =.Pectoralis_minor2_cyl.Cylinder.Segment.node1.Surf;
@@ -950,7 +950,7 @@ AnyMuscleShortestPath pectoralis_major_clavicular_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_major_clavicular_part_2; 
   AnyRefNode &Org = ..Seg.Clavicula.O_pectoralis_major_clavicular_part_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_pectoralis_major_clavicular_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 60;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   //AnySurfSphere &Surf2 =.art_tub_minus_tub_majusRef;
@@ -963,7 +963,7 @@ AnyMuscleShortestPath pectoralis_major_clavicular_part_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_major_clavicular_part_3; 
   AnyRefNode &Org = ..Seg.Clavicula.O_pectoralis_major_clavicular_part_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_pectoralis_major_clavicular_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 50;
   AnyParamSurf& Surf = ..ShoulderRef.PectoralisWrappingSurface;
   //AnySurfSphere &Surf2 =.art_tub_minus_tub_majusRef;
@@ -999,7 +999,7 @@ AnyMuscleViaPoint pectoralis_minor_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_minor_1; 
   AnyRefNode &Org = ..ShoulderRef.O_pectoralis_minor_1; 
   AnyRefNode &Ins = ..Seg.Scapula.I_pectoralis_minor_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 
@@ -1033,7 +1033,7 @@ AnyMuscleViaPoint pectoralis_minor_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_minor_2; 
   AnyRefNode &Org = ..ShoulderRef.O_pectoralis_minor_2; 
   AnyRefNode &Ins = ..Seg.Scapula.I_pectoralis_minor_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 
@@ -1041,7 +1041,7 @@ AnyMuscleViaPoint pectoralis_minor_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.pectoralis_minor_3; 
   AnyRefNode &Org = ..ShoulderRef.O_pectoralis_minor_3; 
   AnyRefNode &Ins = ..Seg.Scapula.I_pectoralis_minor_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 
@@ -1049,7 +1049,7 @@ AnyMuscleViaPoint rhomboideus_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.rhomboideus_1; 
   AnyRefNode &Org = ..C7SegRef.O_rhomboideus_1; 
   AnyRefNode &Ins = ..Seg.Scapula.I_rhomboideus_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
 };
 
@@ -1057,21 +1057,21 @@ AnyMuscleViaPoint rhomboideus_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.rhomboideus_2; 
   AnyRefNode &Org = ..ShoulderRef.O_rhomboideus_2; 
   AnyRefNode &Ins = ..Seg.Scapula.I_rhomboideus_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint rhomboideus_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.rhomboideus_3; 
   AnyRefNode &Org = ..ShoulderRef.O_rhomboideus_3; 
   AnyRefNode &Ins = ..Seg.Scapula.I_rhomboideus_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleShortestPath serratus_anterior_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_1; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_1; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine = {
@@ -1087,7 +1087,7 @@ AnyMuscleShortestPath serratus_anterior_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_2; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_2; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine.InitWrapPosVecArr = .serratus_anterior_1.SPLine.InitWrapPosVecArr;
@@ -1097,7 +1097,7 @@ AnyMuscleShortestPath serratus_anterior_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_3; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_3; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine.InitWrapPosVecArr = .serratus_anterior_1.SPLine.InitWrapPosVecArr;
@@ -1107,7 +1107,7 @@ AnyMuscleShortestPath serratus_anterior_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_4; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_4; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 56;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine.InitWrapPosVecArr = .serratus_anterior_1.SPLine.InitWrapPosVecArr;
@@ -1117,7 +1117,7 @@ AnyMuscleShortestPath serratus_anterior_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_5; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_5; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 40;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine.InitWrapPosVecArr = .serratus_anterior_1.SPLine.InitWrapPosVecArr;
@@ -1127,7 +1127,7 @@ AnyMuscleShortestPath serratus_anterior_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.serratus_anterior_6; 
   AnyRefNode &Org = ..ShoulderRef.O_serratus_anterior_6; 
   AnyRefNode &Ins = ..Seg.Scapula.I_serratus_anterior_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 40;
   AnySurfEllipsoid& Surf = ..ShoulderRef.SerratusAnteriorWrappingSurface;
   SPLine.InitWrapPosVecArr = .serratus_anterior_1.SPLine.InitWrapPosVecArr;
@@ -1139,7 +1139,7 @@ AnyMuscleShortestPath serratus_anterior_6 = {
     AnyRefNode &Ins = ..ShoulderRef.SternocleidomastoidNode;
     AnyRefNode &Via = ..SkullSegRef.SternocleidomastoidNode;
     AnyRefNode &Ins2 = ..Seg.Clavicula.SternocleidomastoidNode;
-    viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+    viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   };
 */  
 
@@ -1147,7 +1147,7 @@ AnyMuscleShortestPath subscapularis_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.subscapularis_1; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1169,7 +1169,7 @@ AnyMuscleShortestPath subscapularis_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.subscapularis_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1180,7 +1180,7 @@ AnyMuscleShortestPath subscapularis_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.subscapularis_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh =100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1192,7 +1192,7 @@ AnyMuscleShortestPath subscapularis_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.subscapularis_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1203,7 +1203,7 @@ AnyMuscleShortestPath subscapularis_5 = {
   AnyMuscleModel &MusMdl =  ..MuscleModels.subscapularis_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1214,7 +1214,7 @@ AnyMuscleShortestPath subscapularis_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.subscapularis_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_subscapularis_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_subscapularis_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnyParamSurf &Surf1 = ..Seg.Scapula.subscapularis_torus.surface;
   AnyParamSurf &Surf2 = ..Seg.Humerus.SubscapularisHumerusWrapping.cyl;
@@ -1225,7 +1225,7 @@ AnyMuscleShortestPath supraspinatus_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_1; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine = {
@@ -1238,7 +1238,7 @@ AnyMuscleShortestPath supraspinatus_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine.InitWrapPosVecArr = .supraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -1248,7 +1248,7 @@ AnyMuscleShortestPath supraspinatus_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine.InitWrapPosVecArr = .supraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -1258,7 +1258,7 @@ AnyMuscleShortestPath supraspinatus_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine.InitWrapPosVecArr = .supraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -1268,7 +1268,7 @@ AnyMuscleShortestPath supraspinatus_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine.InitWrapPosVecArr = .supraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -1278,7 +1278,7 @@ AnyMuscleShortestPath supraspinatus_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.supraspinatus_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_supraspinatus_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_supraspinatus_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 20;
   AnySurfEllipsoid &Surf =.art_gh_humRef;
   SPLine.InitWrapPosVecArr = .supraspinatus_1.SPLine.InitWrapPosVecArr;
@@ -1288,7 +1288,7 @@ AnyMuscleShortestPath teres_major_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_1; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_1; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1304,7 +1304,7 @@ AnyMuscleShortestPath teres_major_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_2; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1315,7 +1315,7 @@ AnyMuscleShortestPath teres_major_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 40;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1326,7 +1326,7 @@ AnyMuscleShortestPath teres_major_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1337,7 +1337,7 @@ AnyMuscleShortestPath teres_major_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_5;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1348,7 +1348,7 @@ AnyMuscleShortestPath teres_major_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_major_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_major_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_major_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnySurfCylinder &Surf =.collum_hum_teres_minor_major;
   AnySurfCylinder &Surf2 =.teresmajor_cyl;
@@ -1359,7 +1359,7 @@ AnyMuscleShortestPath teres_minor_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_1; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_1;//Correction to make wrap work
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_1;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine = {
@@ -1379,7 +1379,7 @@ AnyMuscleShortestPath teres_minor_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_2; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_2;//Correction to make wrap work
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_2;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .teres_minor_1.SPLine.InitWrapPosVecArr;
@@ -1389,7 +1389,7 @@ AnyMuscleShortestPath teres_minor_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_3; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_3; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .teres_minor_1.SPLine.InitWrapPosVecArr;
@@ -1399,7 +1399,7 @@ AnyMuscleShortestPath teres_minor_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_4; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_4; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .teres_minor_1.SPLine.InitWrapPosVecArr;
@@ -1409,7 +1409,7 @@ AnyMuscleShortestPath teres_minor_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_5; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_5; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .teres_minor_1.SPLine.InitWrapPosVecArr;
@@ -1419,7 +1419,7 @@ AnyMuscleShortestPath teres_minor_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.teres_minor_6; 
   AnyRefNode &Org = ..Seg.Scapula.O_teres_minor_6; 
   AnyRefNode &Ins = ..Seg.Humerus.I_teres_minor_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 30;
   AnyParamSurf &Surf =..Seg.Humerus.teres_minor_humurus_wrap.torus;
   SPLine.InitWrapPosVecArr = .teres_minor_1.SPLine.InitWrapPosVecArr;
@@ -1444,7 +1444,7 @@ AnyMuscleShortestPath trapezius_scapular_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_scapular_part_2; 
   AnyRefNode &Org = ..ShoulderRef.O_trapezius_scapular_part_2; 
   AnyRefNode &Ins = ..Seg.Scapula.I_trapezius_scapular_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any" };
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any" };
   SPLine.StringMesh = 100;
   AnySurfCylinder &Surf =.margo_medialis;
   SPLine.InitWrapPosVecArr = .trapezius_scapular_part_1.SPLine.InitWrapPosVecArr;
@@ -1455,7 +1455,7 @@ AnyMuscleShortestPath trapezius_scapular_part_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_scapular_part_3; 
   AnyRefNode &Org = ..ShoulderRef.O_trapezius_scapular_part_3; 
   AnyRefNode &Ins = ..Seg.Scapula.I_trapezius_scapular_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnySurfCylinder &Surf =.margo_medialis;
   SPLine.InitWrapPosVecArr = .trapezius_scapular_part_1.SPLine.InitWrapPosVecArr;
@@ -1465,21 +1465,21 @@ AnyMuscleViaPoint trapezius_scapular_part_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_scapular_part_4; 
   AnyRefNode &Org = ..ShoulderRef.O_trapezius_scapular_part_4; 
   AnyRefNode &Ins = ..Seg.Scapula.I_trapezius_scapular_part_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_scapular_part_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_scapular_part_5; 
   AnyRefNode &Org = ..ShoulderRef.O_trapezius_scapular_part_5; 
   AnyRefNode &Ins = ..Seg.Scapula.I_trapezius_scapular_part_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_scapular_part_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_scapular_part_6; 
   AnyRefNode &Org = ..ShoulderRef.O_trapezius_scapular_part_6; 
   AnyRefNode &Ins = ..Seg.Scapula.I_trapezius_scapular_part_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 /*
@@ -1487,42 +1487,42 @@ AnyMuscleViaPoint  trapezius_clavicular_part_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_1; 
   AnyRefNode &Org = ..C5SegRef.O_trapezius_clavicular_part_1; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_clavicular_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_2; 
   AnyRefNode &Org = ..C4SegRef.O_trapezius_clavicular_part_2; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_clavicular_part_3 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_3; 
   AnyRefNode &Org = ..C3SegRef.O_trapezius_clavicular_part_3; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_clavicular_part_4 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_4; 
   AnyRefNode &Org = ..C2SegRef.O_trapezius_clavicular_part_4; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_clavicular_part_5 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_5; 
   AnyRefNode &Org = ..C1SegRef.O_trapezius_clavicular_part_5; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint trapezius_clavicular_part_6 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.trapezius_clavicular_part_6; 
   AnyRefNode &Org = ..SkullSegRef.O_trapezius_clavicular_part_6; 
   AnyRefNode &Ins = ..Seg.Clavicula.I_trapezius_clavicular_part_6; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 */
 
@@ -1539,7 +1539,7 @@ AnyMuscleShortestPath Brachialis_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Brachialis_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Brachialis_1; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Brachialis_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.condylus_hum;
   SPLine.StringMesh = 30; 
   SPLine = {
@@ -1557,7 +1557,7 @@ AnyMuscleShortestPath Brachialis_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Brachialis_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Brachialis_2; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Brachialis_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.condylus_hum;
   SPLine.StringMesh = 30; 
   SPLine = {
@@ -1570,7 +1570,7 @@ AnyMuscleShortestPath Triceps_LH_1 = {
   AnyRefNode &Org = ..Seg.Scapula.O_Triceps_LH_1;
   AnyRefNode &Via = ..Seg.Humerus.Via_Triceps_LH_1;
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_LH_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 70; 
   AnySurfCylinder &Surf1 =.oleacron;
   AnyParamSurf &Surf2 = .TricepsLHWrapping.BASE_FRAME.Wrapping_1.Surf;
@@ -1592,7 +1592,7 @@ AnyMuscleShortestPath Triceps_LH_2 = {
   AnyRefNode &Org =..Seg.Scapula.O_Triceps_LH_2; 
   AnyRefNode &Via = ..Seg.Humerus.Via_Triceps_LH_2;
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_LH_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 70; 
   AnySurfCylinder &Surf1 =.oleacron;
   AnyParamSurf &Surf2 = .TricepsLHWrapping.BASE_FRAME.Wrapping_1.Surf;
@@ -1605,7 +1605,7 @@ AnyMuscleShortestPath Triceps_ME_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Triceps_ME_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Triceps_ME_1; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_ME_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 100;
   AnySurfCylinder &Surf1 =.oleacron;
   SPLine = {
@@ -1617,7 +1617,7 @@ AnyMuscleShortestPath Triceps_ME_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Triceps_ME_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Triceps_ME_2; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_ME_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 90;
   AnySurfCylinder &Surf1 =.oleacron;
   SPLine = {
@@ -1629,7 +1629,7 @@ AnyMuscleShortestPath Triceps_LA_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Triceps_LA_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Triceps_LA_1; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_LA_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.oleacron;
   SPLine.StringMesh = 90;
   SPLine = {
@@ -1641,7 +1641,7 @@ AnyMuscleShortestPath Triceps_LA_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Triceps_LA_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Triceps_LA_2; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Triceps_LA_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.oleacron;
   SPLine.StringMesh = 90; 
   SPLine = {
@@ -1653,7 +1653,7 @@ AnyMuscleShortestPath Brach_rad_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Brach_rad_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Brach_rad_1; 
   AnyRefNode &Ins = ..Seg.Radius.I_Brach_rad_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.condylus_hum;
   
   SPLine.StringMesh = 50; 
@@ -1670,7 +1670,7 @@ AnyMuscleShortestPath Brach_rad_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Brach_rad_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Brach_rad_2; 
   AnyRefNode &Ins = ..Seg.Radius.I_Brach_rad_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.condylus_hum;
   SPLine.StringMesh = 50; 
   SPLine = {
@@ -1685,21 +1685,21 @@ AnyMuscleViaPoint Anconeus_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Anconeus_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Anconeus_1; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Anconeus_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint Anconeus_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Anconeus_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Anconeus_2; 
   AnyRefNode &Ins = ..Seg.Ulna.I_Anconeus_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleShortestPath Pronator_teres_caput_humeral_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Pronator_teres_caput_humeral_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Pronator_teres_caput_humeral_1; 
   AnyRefNode &Ins = ..Seg.Radius.I_Pronator_teres_caput_humeral_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.pronatorterescyl;
   SPLine.StringMesh = 45;
   SPLine = {
@@ -1716,7 +1716,7 @@ AnyMuscleShortestPath Pronator_teres_caput_humeral_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Pronator_teres_caput_humeral_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Pronator_teres_caput_humeral_2; 
   AnyRefNode &Ins = ..Seg.Radius.I_Pronator_teres_caput_humeral_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.pronatorterescyl;
   SPLine.StringMesh = 45;
   SPLine = {
@@ -1734,7 +1734,7 @@ AnyMuscleShortestPath Pronator_teres_caput_ulnare_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Pronator_teres_caput_ulnare; 
   AnyRefNode &Org =..Seg.Ulna.O_Pronator_teres_caput_ulnare_1; 
   AnyRefNode &Ins = ..Seg.Radius.I_Pronator_teres_caput_ulnare_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any" };
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any" };
   AnySurfCylinder &Surf1 =.pronatorterescyl;
   SPLine.StringMesh = 35;
   SPLine = {
@@ -1753,7 +1753,7 @@ AnyMuscleShortestPath Supinator_humerus_part_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Supinator_humerus_part_1; 
   AnyRefNode &Org = ..Seg.Humerus.O_Supinator_humerus_part_1; 
   AnyRefNode &Ins =..Seg.Radius.I_Supinator_humerus_part_1;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.supinatorcyl;
   SPLine.StringMesh = 25;
   SPLine = {
@@ -1768,7 +1768,7 @@ AnyMuscleShortestPath Supinator_humerus_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Supinator_humerus_part_2; 
   AnyRefNode &Org = ..Seg.Humerus.O_Supinator_humerus_part_2; 
   AnyRefNode &Ins = ..Seg.Radius.I_Supinator_humerus_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.supinatorcyl;
   SPLine.StringMesh = 30;
   SPLine = {
@@ -1783,7 +1783,7 @@ AnyMuscleShortestPath Supinator_ulna_part_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Supinator_ulna_part_1; 
   AnyRefNode &Org = ..Seg.Ulna.O_Supinator_ulna_part_1;
   AnyRefNode &Ins = ..Seg.Radius.I_Supinator_ulna_part_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.supinatorcyl;
   
   SPLine.StringMesh = 35;
@@ -1804,7 +1804,7 @@ AnyMuscleShortestPath Supinator_ulna_part_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Supinator_ulna_part_2; 
   AnyRefNode &Org = ..Seg.Ulna.O_Supinator_ulna_part_2; 
   AnyRefNode &Ins = ..Seg.Radius.I_Supinator_ulna_part_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf1 =.supinatorcyl;
   SPLine.StringMesh = 25;
   SPLine = {
@@ -1823,14 +1823,14 @@ AnyMuscleViaPoint Pron_quadr_1 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Pron_quadr_1; 
   AnyRefNode &Org = ..Seg.Ulna.O_Pron_quadr_1; 
   AnyRefNode &Ins = ..Seg.Radius.I_Pron_quadr_1; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleViaPoint Pron_quadr_2 = {
   AnyMuscleModel &MusMdl = ..MuscleModels.Pron_quadr_2; 
   AnyRefNode &Org = ..Seg.Ulna.O_Pron_quadr_2; 
   AnyRefNode &Ins = ..Seg.Radius.I_Pron_quadr_2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 };
 
 AnyMuscleShortestPath Extensor_Indicis ={
@@ -1839,18 +1839,29 @@ AnyMuscleShortestPath Extensor_Indicis ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Indicis; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via1_Extensor_Indicis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Indicis; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
         transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)               
     };
     InitWrapPosVecArr = {None, &InitWrapPos, None };
   };
-
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleViaPoint Abductor_Pollicis_Longus ={
@@ -1868,7 +1879,7 @@ AnyMuscleViaPoint Abductor_Pollicis_Longus ={
   
   // AnySurfCylinder &Surf2 =..Seg.Radius.RadiusMuscleCyl.cyl;
   // AnySurfCylinder &Surf3 =..Seg.Ulna.UlnaMuscleCyl.cyl;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
 //  SPLine.StringMesh = 45;
 //  SPLine.RelTol=0.0000001;
@@ -1888,7 +1899,7 @@ AnyMuscleShortestPath Extensor_Pollicis_Brevis ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Pollicis_Longus; 
   AnyRefNode &Org = ..Seg.Radius.O_Extensor_Pollicis_Brevis; 
   
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
   SPLine.StringMesh = 30;
   SPLine.RelTol=0.0000001;
@@ -1907,7 +1918,7 @@ AnyMuscleShortestPath Extensor_Pollicis_Longus ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Pollicis_Longus; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger1MetaRef.Via1_Extensor_Pollicis_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger1MetaRef.I_Extensor_Pollicis_Longus; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
   
   SPLine.StringMesh = 45;
@@ -1926,7 +1937,7 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Longus ={
   AnyRefNode &Org = ..Seg.Humerus.O_Extensor_Carpi_Radialis_Longus; 
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Carpi_Radialis_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Carpi_Radialis_Longus; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 45;
   SPLine.AbsTol=1e-6;
   SPLine.RelTol=1e-7;
@@ -1943,15 +1954,28 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Carpi_Radialis_Brevis; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Extensor_Carpi_Radialis_Brevis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Carpi_Radialis_Brevis; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 60;
-  SPLine.RelTol=10e-6;
-  SPLine.AbsTol=10e-6;
   SPLine = {
     AnyMatrix InitWrapPos = {transf3D({...Sign*1*.Surf1.Radius, 1.1*.Surf1.Radius, 0.35*.Surf1.Length }, &.Surf1)};
     InitWrapPosVecArr = { None, &InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*0.8*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 60;
+  SPLine.RelTol=10e-6;
+  SPLine.AbsTol=10e-6;
 };
 
 
@@ -1963,7 +1987,7 @@ AnyMuscleShortestPath Extensor_Carpi_Ulnaris ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Extensor_Carpi_Ulnaris;
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Carpi_Ulnaris; 
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   SPLine.StringMesh = 35;
   SPLine.RelTol=0.0000001;
   SPLine = {
@@ -1980,7 +2004,7 @@ AnyMuscleShortestPath Flexor_Carpi_Ulnaris  ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Flexor_Carpi_Ulnaris; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Carpi_Ulnaris; 
   
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   AnySurfCylinder &Surf2 =..Seg.Radius.FlexorMuscleCyl.cyl;
   SPLine.StringMesh = 30;
   SPLine = {
@@ -1999,11 +2023,11 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
   AnyRefNode &Org = ..Seg.Humerus.O_Flexor_Carpi_Radialis; 
   AnyRefNode &Via2 = ..Seg.Radius.Via_Flexor_Carpi_Radialis; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Carpi_Radialis; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf2 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf2.Radius, -1.2*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2 ) ,              
@@ -2011,6 +2035,19 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.7*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Palmaris_Longus  ={
@@ -2019,10 +2056,10 @@ AnyMuscleShortestPath Palmaris_Longus  ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Palmaris_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Palmaris_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};  
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -2030,6 +2067,19 @@ AnyMuscleShortestPath Palmaris_Longus  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 
@@ -2039,10 +2089,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Superficialis_Digit5; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Flexor_Digitorum_Superficialis_Digit5; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Superficialis_Digit5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -2050,6 +2100,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
@@ -2058,11 +2121,11 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Superficialis_Digit4; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger4MetaRef.Via_Flexor_Digitorum_Superficialis_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Superficialis_Digit4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
@@ -2070,6 +2133,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
@@ -2078,11 +2154,11 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Superficialis_Digit3; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Flexor_Digitorum_Superficialis_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Superficialis_Digit3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=0.0000001;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
@@ -2090,6 +2166,19 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=0.0000001;
 };
 AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyMuscleModel &MusMdl = ..MuscleModels.Flexor_Digitorum_Superficialis_Digit2; 
@@ -2097,10 +2186,11 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Superficialis_Digit2; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via_Flexor_Digitorum_Superficialis_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Superficialis_Digit2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
   //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 30;
   SPLine = {
     AnyMatrix InitWrapPos = {
         transf3D({-0.015, ...Sign*0, -0.000}, &.Via1 ),               
@@ -2108,7 +2198,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos, None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 30;
 };
 
 
@@ -2118,9 +2219,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Profundus_Digit5; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Flexor_Digitorum_Profundus_Digit5; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Profundus_Digit5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
@@ -2128,7 +2230,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2138,9 +2251,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Profundus_Digit4; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger4MetaRef.Via_Flexor_Digitorum_Profundus_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Profundus_Digit4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
@@ -2148,7 +2262,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2158,9 +2283,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Profundus_Digit3; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger3MetaRef.Via_Flexor_Digitorum_Profundus_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Profundus_Digit3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
@@ -2168,6 +2294,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 
@@ -2178,9 +2316,10 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Digitorum_Profundus_Digit2; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger2MetaRef.Via_Flexor_Digitorum_Profundus_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Profundus_Digit2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 35;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
@@ -2188,6 +2327,18 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 35;
 };
 
 AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
@@ -2198,12 +2349,11 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
   AnyRefNode &Via1 = ..Seg.Hand.Finger5MetaRef.Via_Extensor_Digitorum_Digit5; 
   
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digitorum_Digit5; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {    
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2211,7 +2361,21 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
     };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
+};
 
 
 AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
@@ -2220,12 +2384,11 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Extensor_Digitorum_Digit4; 
   AnyRefNode &Via1 = ..Seg.Hand.Finger4MetaRef.Via_Extensor_Digitorum_Digit4; 
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Extensor_Digitorum_Digit4; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2233,6 +2396,20 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.15*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2242,12 +2419,11 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Extensor_Digitorum_Digit3; 
   AnyRefNode &Via1 = ..Seg.Hand.Finger3MetaRef.Via_Extensor_Digitorum_Digit3; 
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Digitorum_Digit3; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = { 
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2255,6 +2431,20 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.25*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2264,10 +2454,11 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
   AnyRefNode &Via2 = ..Seg.Radius.Via_Extensor_Digitorum_Digit2; 
   AnyRefNode &Via1 = ..Seg.Hand.Finger2MetaRef.Via_Extensor_Digitorum_Digit2; 
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Digitorum_Digit2; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 50;
   SPLine = {
     AnyMatrix InitWrapPos1 = {
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2275,6 +2466,18 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.35*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 50;
 };
 
 
@@ -2285,12 +2488,11 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Extensor_Digiti_Minimi; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger5MetaRef.Via_Extensor_Digiti_Minimi; 
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digiti_Minimi; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
   AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine.StringMesh = 30;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos1 = {
       transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
@@ -2298,6 +2500,20 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
     AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)};
     InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2,None };
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 30;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };
 
 
@@ -2307,11 +2523,10 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
   AnyRefNode &Via1 = ..Seg.Radius.Via_Flexor_Pollicis_Longus; 
   AnyRefNode &Via2 = ..Seg.Hand.Finger1MetaRef.Via_Flexor_Pollicis_Longus; 
   AnyRefNode &Ins = ..Seg.Hand.Finger1MetaRef.I_Flexor_Pollicis_Longus; 
-  viewMuscle = {#include "../drawSettings/MusDrawSettings.any"};
+  viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
+  
+  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
   AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine.StringMesh = 25;
-  SPLine.RelTol=1e-7;
-  SPLine.AbsTol=1e-5;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
@@ -2319,4 +2534,18 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos, None};
   };
+  #else
+  AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
+//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
+  SPLine = {
+    AnyMatrix InitWrapPos = {
+      transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
+       transf3D({-0.8*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2]  }, &.Surf1 )           
+    };
+    InitWrapPosVecArr = {None,&InitWrapPos,None};
+  };
+  #endif
+  SPLine.StringMesh = 25;
+  SPLine.RelTol=1e-7;
+  SPLine.AbsTol=1e-5;
 };

--- a/Body/AAUHuman/Arm/Muscle.any
+++ b/Body/AAUHuman/Arm/Muscle.any
@@ -1841,17 +1841,7 @@ AnyMuscleShortestPath Extensor_Indicis ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Indicis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-        transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)               
-    };
-    InitWrapPosVecArr = {None, &InitWrapPos, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1859,7 +1849,6 @@ AnyMuscleShortestPath Extensor_Indicis ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -1956,15 +1945,7 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Carpi_Radialis_Brevis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {transf3D({...Sign*1*.Surf1.Radius, 1.1*.Surf1.Radius, 0.35*.Surf1.Length }, &.Surf1)};
-    InitWrapPosVecArr = { None, &InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -1972,7 +1953,6 @@ AnyMuscleShortestPath Extensor_Carpi_Radialis_Brevis ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 60;
   SPLine.RelTol=10e-6;
   SPLine.AbsTol=10e-6;
@@ -2025,19 +2005,7 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Carpi_Radialis; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf2 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf1 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf2.Radius, -1.2*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2 ) ,              
-       transf3D({...Sign*0*.Surf2.Radius, -1.2*.Surf2.Radius, 0.45*.Surf2.Length }, &.Surf2 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-0.8*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2045,7 +2013,6 @@ AnyMuscleShortestPath Flexor_Carpi_Radialis  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2057,19 +2024,7 @@ AnyMuscleShortestPath Palmaris_Longus  ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Palmaris_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};  
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2077,7 +2032,6 @@ AnyMuscleShortestPath Palmaris_Longus  ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2091,18 +2045,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Superficialis_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0.1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2110,7 +2053,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2123,19 +2065,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Superficialis_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2143,7 +2073,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2156,19 +2085,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Superficialis_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2176,7 +2093,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=0.0000001;
 };
@@ -2188,19 +2104,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Superficialis_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  //AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-        transf3D({-0.015, ...Sign*0, -0.000}, &.Via1 ),               
-        transf3D({...Sign*0*.Surf1.Radius, -1.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos, None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.5*.Surf1.Radius[1], ...Sign*-1.1*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2208,7 +2112,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Superficialis__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 30;
 };
 
@@ -2221,18 +2124,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Flexor_Digitorum_Profundus_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-0.8*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0.1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.55*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2240,7 +2132,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2253,18 +2144,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Flexor_Digitorum_Profundus_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.5*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2272,7 +2152,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2285,18 +2164,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Flexor_Digitorum_Profundus_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.42*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2304,7 +2172,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2318,18 +2185,7 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Flexor_Digitorum_Profundus_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
 
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.47*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.42*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos,None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*-1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2337,7 +2193,6 @@ AnyMuscleShortestPath Flexor_Digitorum_Profundus__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 35;
 };
 
@@ -2351,19 +2206,7 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digitorum_Digit5; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {    
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.1*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2371,7 +2214,6 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit5 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2386,19 +2228,7 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger4MetaRef.I_Extensor_Digitorum_Digit4; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};      
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.2*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2406,7 +2236,6 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit4 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2421,19 +2250,7 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger3MetaRef.I_Extensor_Digitorum_Digit3; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = { 
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.3*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2441,7 +2258,6 @@ AnyMuscleShortestPath  Extensor_Digitorum__Digit3 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2456,19 +2272,7 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
   AnyRefNode &Ins = ..Seg.Hand.Finger2MetaRef.I_Extensor_Digitorum_Digit2; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = {
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*-0.3*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.4*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1, &InitWrapPos2, None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.4*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2476,7 +2280,6 @@ AnyMuscleShortestPath Extensor_Digitorum__Digit2 ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 50;
 };
 
@@ -2490,19 +2293,7 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
   AnyRefNode &Ins = ..Seg.Hand.Finger5MetaRef.I_Extensor_Digiti_Minimi; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Radius.RadiusMuscleCyl.cyl;
-  AnySurfCylinder &Surf2 =..Seg.Radius.MedialExtensorCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos1 = {
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1),
-      transf3D({...Sign*1.3*.Surf1.Radius, ...Sign*0.5*.Surf1.Radius, 0.6*.Surf1.Length }, &.Surf1)};
-    AnyMatrix InitWrapPos2 = {transf3D({...Sign*1*.Surf2.Radius, 1.1*.Surf2.Radius, 0.5*.Surf2.Length }, &.Surf2)};
-    InitWrapPosVecArr = { &InitWrapPos1,&InitWrapPos2,None };
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.ExtensorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.ExtensorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.05*.Surf1.Radius[1], ...Sign*1.0*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2510,7 +2301,6 @@ AnyMuscleShortestPath  Extensor_Digiti_Minimi ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 30;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;
@@ -2525,18 +2315,7 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
   AnyRefNode &Ins = ..Seg.Hand.Finger1MetaRef.I_Flexor_Pollicis_Longus; 
   viewMuscle = {#include "../DrawSettings/MusDrawSettings.any"};
   
-  #if BM_WRIST_MUS_WRAPPING != ELLIPSOID
-  AnySurfCylinder &Surf1 =..Seg.Hand.CarpalsRef.FlexorMuscleCyl.cyl;
-  SPLine = {
-    AnyMatrix InitWrapPos = {
-      transf3D({...Sign*-1*.Surf1.Radius, -1.2*.Surf1.Radius, 0.45*.Surf1.Length }, &.Surf1 ) ,              
-       transf3D({...Sign*0*.Surf1.Radius, -1.2*.Surf1.Radius, 0.4*.Surf1.Length }, &.Surf1 )               
-    };
-    InitWrapPosVecArr = {None,&InitWrapPos, None};
-  };
-  #else
   AnySurfEllipsoid &Surf1 = ..Seg.Radius.FlexorMuscleEllipsoid.ellipsoid;
-//  AnySurfTorus &Surf2 = ..Seg.Radius.FlexorMuscleTorus.torus;
   SPLine = {
     AnyMatrix InitWrapPos = {
       transf3D({-0.2*.Surf1.Radius[0],-0.6*.Surf1.Radius[1], ...Sign*-0.9*.Surf1.Radius[2] }, &.Surf1 ) ,              
@@ -2544,7 +2323,6 @@ AnyMuscleShortestPath  Flexor_Pollicis_Longus ={
     };
     InitWrapPosVecArr = {None,&InitWrapPos,None};
   };
-  #endif
   SPLine.StringMesh = 25;
   SPLine.RelTol=1e-7;
   SPLine.AbsTol=1e-5;

--- a/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
+++ b/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
@@ -126,24 +126,7 @@ Radius = {
        Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
      };
    };
-   // It is used for wrapping of flexor muscles at wrist
-   AnyRefNode FlexorMuscleTorus = {
-     
-     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
-     sRel = P1;
-     AnyVec3 P1 = .Scale(.Data.WristFlexorTorus_pos*.Mirror);
-     AnyVec3 P3 = .Scale(.Data.WristFlexorTorus_P3_pos*.Mirror);
-     AnyVec3 P2 = .Scale(.Data.WristFlexorTorus_P2_pos*.Mirror);
-     
-     //Calculate orientation of Torus
-     ARel = RotMat(P1,P3,P2);
-     
-     AnySurfTorus torus = {
-       MajorRadius = .Radius;
-       MinorRadius = 0.2*MajorRadius;
-     };
-   };
-  
+   
    // It is used for wrapping of extensor muscles at wrist
    AnyRefNode ExtensorMuscleEllipsoid = {
      
@@ -159,23 +142,6 @@ Radius = {
      
      AnySurfEllipsoid ellipsoid = {
        Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
-     };
-   };
-   // It is used for wrapping of extensor muscles at wrist
-   AnyRefNode ExtensorMuscleTorus = {
-     
-     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
-     sRel = P1;
-     AnyVec3 P1 = .Scale(.Data.WristExtensorTorus_pos*.Mirror);
-     AnyVec3 P3 = .Scale(.Data.WristExtensorTorus_P3_pos*.Mirror);
-     AnyVec3 P2 = .Scale(.Data.WristExtensorTorus_P2_pos*.Mirror);
-     
-     //Calculate orientation of Torus
-     ARel = RotMat(P1,P3,P2);
-     
-     AnySurfTorus torus = {
-       MajorRadius = .Radius;
-       MinorRadius = 0.2*MajorRadius;
      };
    };
    

--- a/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
+++ b/Body/AAUHuman/Arm/RadiusMuscleGeometry.any
@@ -109,7 +109,76 @@ Radius = {
    };
     
   
+   // It is used for wrapping of flexor muscles at wrist
+   AnyRefNode FlexorMuscleEllipsoid = {
+     
+     AnyVar DiameterXZ = vnorm(.Scale(.Data.Via_Palmaris_Longus_pos*.Mirror - .Data.Via_Extensor_Indicis_pos*.Mirror));
+     AnyVar DiameterY = vnorm(.Scale(.Data.PS_pos*.Mirror - .Data.rs_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristFlexorEllipsoid_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristFlexorEllipsoid_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristFlexorEllipsoid_P2_pos*.Mirror);
+     
+     //Calculate orientation of ellipsoid
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfEllipsoid ellipsoid = {
+       Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
+     };
+   };
+   // It is used for wrapping of flexor muscles at wrist
+   AnyRefNode FlexorMuscleTorus = {
+     
+     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristFlexorTorus_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristFlexorTorus_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristFlexorTorus_P2_pos*.Mirror);
+     
+     //Calculate orientation of Torus
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfTorus torus = {
+       MajorRadius = .Radius;
+       MinorRadius = 0.2*MajorRadius;
+     };
+   };
   
+   // It is used for wrapping of extensor muscles at wrist
+   AnyRefNode ExtensorMuscleEllipsoid = {
+     
+     AnyVar DiameterXZ = vnorm(.Scale(.Data.Via_Palmaris_Longus_pos*.Mirror - .Data.Via_Extensor_Indicis_pos*.Mirror));
+     AnyVar DiameterY = vnorm(.Scale(.Data.PS_pos*.Mirror - .Data.rs_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristExtensorEllipsoid_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristExtensorEllipsoid_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristExtensorEllipsoid_P2_pos*.Mirror);
+     
+     //Calculate orientation of ellipsoid
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfEllipsoid ellipsoid = {
+       Radius = 0.5*{.DiameterXZ,.DiameterY,.DiameterXZ};
+     };
+   };
+   // It is used for wrapping of extensor muscles at wrist
+   AnyRefNode ExtensorMuscleTorus = {
+     
+     AnyVar Radius = vnorm(.Scale(.Data.Via_Extensor_Carpi_Radialis_Brevis_pos*.Mirror - .Data.Via_Palmaris_Longus_pos*.Mirror));
+     sRel = P1;
+     AnyVec3 P1 = .Scale(.Data.WristExtensorTorus_pos*.Mirror);
+     AnyVec3 P3 = .Scale(.Data.WristExtensorTorus_P3_pos*.Mirror);
+     AnyVec3 P2 = .Scale(.Data.WristExtensorTorus_P2_pos*.Mirror);
+     
+     //Calculate orientation of Torus
+     ARel = RotMat(P1,P3,P2);
+     
+     AnySurfTorus torus = {
+       MajorRadius = .Radius;
+       MinorRadius = 0.2*MajorRadius;
+     };
+   };
+   
   
   #include "../DrawSettings/SegmentAxes.any"
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 * Excluded force plates from the parameter identification study, as they were
   unnecessary. This change may slightly speed up the parameter identification
   process.
+* The wrapping surface for muscles at the wrist has been changed to an ellipsoid
+  from a cylinder. This lowers the risk of muscle via points prenetrating the
+  wrapping surface in postures involving both flexion/extension and
+  abduction/adduction at the wrist.
 
 (ammr-3.0.4-changelog)=
 ## AMMR 3.0.4 (2024-07-02)


### PR DESCRIPTION
This PR replaces @divyaksh-chander's PR ( https://github.com/AnyBody/AMMR4-Beta/pull/33 )on AMMR 4, since this work should have been done directly on AMMR 3. 

> This PR changes the wrapping surface at the wrist to an ellipsoid. This prevents muscle penetration issues that we have seen with the previous wrapping cylinder in postures involving both flexion/extension and abduction/adduction at wrist.