### PR TITLE
fix: correct typo in disc stiffness bm statement

### DIFF
--- a/Body/AAUHuman/Trunk/DiscStiffness.any
+++ b/Body/AAUHuman/Trunk/DiscStiffness.any
@@ -37,7 +37,7 @@
     AnyFloat ligExt      = coef*Ext;
     AnyFloat ligLatbend  = coef*Latbend;
 
-    #if BM_TRUNK_DISC_STIFNESS == _DISC_STIFFNESS_NONE_
+    #if BM_TRUNK_DISC_STIFFNESS == _DISC_STIFFNESS_NONE_
      AnyFunPolynomial Flexfun = {
        PolyCoef={{0, 0}};    
      };
@@ -48,7 +48,7 @@
      AnyFunPolynomial &LBfun_L = Flexfun;    
     #endif
     
-    #if BM_TRUNK_DISC_STIFNESS == _DISC_STIFFNESS_LINEAR_
+    #if BM_TRUNK_DISC_STIFFNESS == _DISC_STIFFNESS_LINEAR_
     
      AnyFunPolynomial Flexfun = {
        PolyCoef=-1*{{0, .ratio*.Flex+.ligFlex}};    
@@ -67,7 +67,7 @@
 
     #endif
     
-    #if BM_TRUNK_DISC_STIFNESS == _DISC_STIFFNESS_NONLINEAR_
+    #if BM_TRUNK_DISC_STIFFNESS == _DISC_STIFFNESS_NONLINEAR_
       // K.S.Han et al. 2010 (in degrees, checked against Heuer et al.)
       //  #Flexion          -0.002x3 + 0.0141x2 - 0.4726x
       //  #Lateral bending  -0.0087x2 - 0.6989x


### PR DESCRIPTION
This is a supplement to PR #1006 that fixed the typo in the BM_TRUNK_DISC_STIFNESS. This PR corrects the typo in the file that implements disc stiffness in the model. This was missed in the previous PR