### PR TITLE
fix: Only call python if it is available

### DIFF
--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
@@ -147,6 +147,7 @@
 // Trigger check for read-only AMMR if we think user is running 
 // the AMMR version in the install directory. 
 #ifpathexists "<ANYBODY_PATH_AMMR>/../AnyBody.exe"
+#ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
 
  #ifndef ANYBODY_DISMISS_READONLY_NOTICE
 
@@ -173,6 +174,7 @@
   "-------------------------------------------------------------------------------------------------------\n"));
 
  #endif
+#endif
 #endif
 
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
@@ -147,7 +147,7 @@
 // Trigger check for read-only AMMR if we think user is running 
 // the AMMR version in the install directory. 
 #ifpathexists "<ANYBODY_PATH_AMMR>/../AnyBody.exe"
-#ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
+#if ANYBODY_PYTHON_AVAILABLE 
 
  #ifndef ANYBODY_DISMISS_READONLY_NOTICE
 

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/BodyModel.defaults.preprocess.any
@@ -179,51 +179,6 @@
 
 
 
- AnyFunEx EndsWith = 
-  {
-    AnyIntVar Return = 0;
-    AnyFunExMonoPy endswith =
-    {
-     ModuleFile = "ammr-checks.py";
-     ArgList = {
-       AnyStringVar string = "";
-       AnyStringVar argument = "";
-     };
-    };
-  };
-  
- #ifdef ANYBODY_ENABLE_MODIFIED_AMMR_NOTICE
- 
- AnyFunEx DirectoryHash = 
-  {
-    AnyStringVar Return = "";
-    AnyFunExMonoPy hash_directory =
-    {
-     ModuleFile = "ammr-checks.py";
-     ArgList = {
-       AnyStringVar Directory = ANYBODY_PATH_BODY;
-     };
-    };
-  };
- 
- AnyStringVar HashBodyModel = DirectoryHash(ANYBODY_PATH_BODY);
- 
- AnyInt ModifiedAMMRChecks = {
-     not(HashBodyModel), // Don't trigger on missing hash value
-     eqfun( ANYBODY_HASH_BODY, HashBodyModel), // Don't trigger if hash value matches
-     EndsWith(AMMR_VERSION, "beta") // Don't trigger if we are using the beta version
-   }; 
- 
- AnyInt BodyModelIsModifiedNotice= notice(sum(ModifiedAMMRChecks), strformat("\n"+
-   "\n------------------------------------------------------------------------------------------------------\n"+
-   "                 Note: You appear to be using a modified version of the Body Model. \n"+
-   "\n"+
-   "  Some files in the folder 'AMMR/Body/AAUHuman' have been modified.\n"+
-   "  You may disable this notice by removing the switch ``#define ANYBODY_ENABLE_MODIFIED_AMMR_NOTICE``                     \n"+
-   "-------------------------------------------------------------------------------------------------------\n"));
-
-#endif
-
 #ifdef BM_TRUNK_THORACIC_FUTURE
 #if BM_TRUNK_THORACIC_FUTURE == ON
    AnyMessage msg_THORACIC_FUTURE = { TriggerPreProcess = On; Type = MSG_Error; Message = strformat("\n"+

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/ammr-beta.any
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/ammr-beta.any
@@ -2,31 +2,18 @@
 AnyDoc _AMMR_BETA_INFO_ = 
 {
    Hidden = On;
-   #ifpathexists "../../../../.git"
+   AnyString GitInfo ??= {"unknown","unknown"};
 
-   #ifdef ANYBODY_PATH_PYTHONHOME
-    #ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
-      #define _READ_GIT_INFO
-    #endif
-   #endif
+#if AMMR_IS_GIT_REPOSITORY
+#if ANYBODY_PYTHON_AVAILABLE
 
-   #ifndef _READ_GIT_INFO
-     #ifpathexists "<ANYBODY_PATH_INSTALLDIR>/Python/python.exe"
-        #define _READ_GIT_INFO
-      #endif
-   #endif
-   
-   #ifdef _READ_GIT_INFO
-   #undef _READ_GIT_INFO
    AnyFunEx ReadGitInfo = {
      AnyString Return = {"",""};
      AnyFunExMonoPy git_info = { ModuleFile = "git_info.py"; ArgList = { AnyString gitfolder = "";};};
    };
-   AnyString GitInfo = ReadGitInfo("../../../../.git");
-   #endif
+   GitInfo= ReadGitInfo(ANYBODY_PATH_AMMR + "/.git");
 
+#endif
+#endif
 
-
-
-   #endif
 };

--- a/Body/AAUHuman/BodyModels/GenericBodyModel/git_info.py
+++ b/Body/AAUHuman/BodyModels/GenericBodyModel/git_info.py
@@ -31,6 +31,16 @@ def git_info(context: tuple, fpath: str) -> Tuple[str, str]:
         subprocess.CalledProcessError: If the git command fails.
         subprocess.TimeoutExpired: If the git command times out.
     """
+    
+    # import debugpy
+    # debugpy.configure({"python":"C:/Program Files/AnyBody Technology/AnyBody.8.1_Beta/Python/python.exe"})
+    # debugpy.listen(5679, in_process_debug_adapter=True)
+    # print('Waiting for debugger attach')
+    # debugpy.wait_for_client()
+    # debugpy.breakpoint()
+    # print('break on this line')
+    
+
     context = AMSContext(*context)
     gitfolder = Path(fpath)
     if not gitfolder.is_absolute():

--- a/Body/AAUHuman/HumanModel.defs.any
+++ b/Body/AAUHuman/HumanModel.defs.any
@@ -13,3 +13,26 @@
 Error("ANYBODY_PATH_TOOLBOX is deprecated. Use ANYBODY_PATH_MODELUTILS instead")
 #endif
 
+
+#ifpathexists "../../.git"
+#define AMMR_IS_GIT_REPOSITORY 1
+#else
+#define AMMR_IS_GIT_REPOSITORY 0
+#endif
+
+
+#define ANYBODY_PYTHON_AVAILABLE 0
+
+#ifdef ANYBODY_PATH_PYTHONHOME
+#ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
+#undef ANYBODY_PYTHON_AVAILABLE
+#define ANYBODY_PYTHON_AVAILABLE 1
+#endif
+#endif
+
+#ifpathexists "<ANYBODY_PATH_INSTALLDIR>/Python/python.exe"
+#undef ANYBODY_PYTHON_AVAILABLE
+#define ANYBODY_PYTHON_AVAILABLE 1
+#endif
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
   wrapping surface in postures involving both flexion/extension and
   abduction/adduction at the wrist.
 
+### Removed: 
+* Removed the python hooks to check for modified AMMR folder. This feature was
+  not used and has been removed to simplify the AMMR codebase.
+
 (ammr-3.0.4-changelog)=
 ## AMMR 3.0.4 (2024-07-02)
 [![Zenodo link](https://zenodo.org/badge/DOI/10.5281/zenodo.12592455.svg)](https://doi.org/10.5281/zenodo.12592455)


### PR DESCRIPTION
This makes AMMR more resilient to AnyBody installations where Python is not available. 

