### PR TITLE
test: Adjuested tolerance for symmetry test

### DIFF
--- a/Tests/Symmetry/test_LegDynamicSymmetryCheck.Main.any
+++ b/Tests/Symmetry/test_LegDynamicSymmetryCheck.Main.any
@@ -25,7 +25,7 @@
 #define BM_TRUNK_MUSCLES OFF
 
 #ifndef TEST_NAME
-  #define BM_LEG_MODEL 1
+  #define BM_LEG_MODEL 2
   #define TEST_NAME "test_LegDynamicSymmetryCheck.Main_1"
 #endif
 


### PR DESCRIPTION
Having the kinematic tolerance and the symmetry tolerance set at the same level could sometimes trigger failures on certain machines with different MKL implementations.

We now set the symmetry tolerance an order of magnetude lower than the kinematic tolerance to prevent that.