### PR TITLE
fix: remove designvar for muscle activity output in EvaluateMaxLoad class template

### DIFF
--- a/Tests/Applications/test_EvalMaxLoad_loadonly.any
+++ b/Tests/Applications/test_EvalMaxLoad_loadonly.any
@@ -1,0 +1,17 @@
+#include "../libdef.any"
+
+#include "../../Application/Validation/EvaluateMaxExternalLoading/EvalMaxLoad.main.any"
+
+Main = 
+{
+#ifndef CREATE_IMAGE
+//  AnyOperation& RunTest = Main.RunApplication;
+  Study = { FixTestStudyConfig TestStudyConfig = {  }; };
+#else
+  #include "../Cameras.any"
+  AnyOperation& CameraInitPos = Main.Study.InitialConditions;
+  LoadTimeCam.CameraLookAtPoint = {0.15,0.3,0};
+  LoadTimeCam.CameraFieldOfView = DesignVar(1);
+  LoadTimeCam.CameraDirection  = {0,0,1};
+#endif
+};

--- a/Tools/ModelUtilities/Validation/EvaluateMaxExternalLoad.any
+++ b/Tools/ModelUtilities/Validation/EvaluateMaxExternalLoad.any
@@ -31,8 +31,8 @@
       #var AnyVar Load1 = InitialLoad;
       #var AnyVar Load2 = 2*InitialLoad;
       AnyVector MaxMuscleActivityTemp = take(arrcat(STUDY.MaxMusActFun_##__NAME__(), zeros(STUDY.nStep)), iarr(0,STUDY.nStep-1));
-      AnyVector MaxMuscleActivity1 = DesignVar(MaxMuscleActivityTemp);
-      AnyVector MaxMuscleActivity2 = DesignVar(MaxMuscleActivityTemp);
+      AnyVector MaxMuscleActivity1 = MaxMuscleActivityTemp;
+      AnyVector MaxMuscleActivity2 = MaxMuscleActivityTemp;
       AnyVector MaxMuscleActivityDiff = (MaxMuscleActivity2 - MaxMuscleActivity1);
       AnyVector a = (MaxMuscleActivityDiff)/(Load2 -Load1) + 0.01*not(MaxMuscleActivityDiff);
       AnyVector MaxLoad = 1/a - div(MaxMuscleActivity1, a) + Load1;


### PR DESCRIPTION
This PR fixes a small bug in the Evaluate Max External Load class template. The muscle activity was cast as designvar but it will not be ready till outputvar.