### PR TITLE
chore: update nightly tests container to version 8.1.0beta2

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -67,7 +67,7 @@ jobs:
   test-linux:
     if: github.repository == 'anybody/ammr'
     runs-on: ubuntu-latest
-    container: ghcr.io/anybody/anybodycon-github-actions:8.0.5rc1
+    container: ghcr.io/anybody/anybodycon-github-actions:8.1.0beta2
     env:
       ANYBODY_SUPPRESS_DEPRECATION_MESSAGES: "Off"
 


### PR DESCRIPTION
I have made a linux container with AMS 8.1.0beta2. This PR updates the nightly tests to use that container. 

Once this is merged to AMMR 4, it should fix the failures on nightly tests  due to missing "flattenptr()" function. 