### PR TITLE
feat: add redirect page for AMMR documentation

### DIFF
--- a/Documentation/index.html
+++ b/Documentation/index.html
@@ -1,0 +1,15 @@
+<!-- You are This page is a redirect to the AMMR documentation -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=https://anyscript.org/ammr/beta">
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>You are viewing the development version of the AnyBody Managed model repository 
+    (AMMR). The documentation must be built from the docs folder. We are redirecting you 
+    to the hosted online version. <a href="https://anyscript.org/ammr/beta">link to the AMMR documentation</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
This PR will ensure that the documenation still works even if the repo is downloaded directly from github as zip file. 