### PR TITLE
Refactor Trunk Joint Driver implementation for MoCap models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 % A rendered version of the CHANGELOG is avaible here:
 %    https://anyscript.org/ammr/beta/changelog.html
 
+(ammr-3.1.2-changelog)=
+## AMMR 3.1.2 (2025-??-??)
+
+
+* Improved how kinematics calculated in marker tracking is applied 
+  to inverse dynamics MoCap models. The previous
+  method for applying joint angles from marker tracking could sometimes
+  struggle with complex rotations (gimbal lock situations). The updated
+  implementation enhances the stability of the kinematic solver, particularly
+  for pelvis positioning, leading to more reliable motion analysis.
+  
+  TL;DR: The implentation was previously using `AnyKinMeasureLinComb` to
+  allow for adding a pelvis offset. This had the side effect that the kinematic
+  solver had a diffculties handing solution close to gimbal locks (+/- pi
+  radians). The new implementation only includes the 3 pelvis positions in the
+  `AnyKinMeasureComb` instead of all trunk angles. This makes the kinematic
+  solver more robust and it is now able to handle gimbal locks better.
+
+
 (ammr-3.1.0-changelog)=
 ## AMMR 3.1.0 (2025-03-31)
 [![Zenodo link](https://zenodo.org/badge/DOI/10.5281/zenodo.15094590.svg)](https://doi.org/10.5281/zenodo.15094590)

--- a/Tools/AnyMocap/JointsAndDriversOptimized.any
+++ b/Tools/AnyMocap/JointsAndDriversOptimized.any
@@ -27,34 +27,32 @@ AnyKinDriver JntDriverTrunkFull = {
     )
   );
   AnyVector PelvisPosOffset ??= {0,0,0};
-  AnyKinMeasureLinComb Measure = {
+  AnyKinMeasureLinComb PelvisPos = {
     AnyKinMeasureOrg Input = {
       AnyKinMeasure& PelvisPosX = .....BodyModel.Interface.Trunk.PelvisPosX;
       AnyKinMeasure& PelvisPosY = .....BodyModel.Interface.Trunk.PelvisPosY;
       AnyKinMeasure& PelvisPosZ = .....BodyModel.Interface.Trunk.PelvisPosZ;
-      
-      AnyKinMeasure& PelvisRotVec = .....BodyModel.Interface.Trunk.PelvisRotVec;
-      
-      AnyKinMeasureOrg& SacrumPelvis = .....BodyModel.Interface.Trunk.Spine.SacrumPelvis;
-      AnyKinMeasureOrg& L5Sacrum =.....BodyModel.Interface.Trunk.Spine.L5Sacrum;
-      AnyKinMeasureOrg& L4L5 =.....BodyModel.Interface.Trunk.Spine.L4L5;
-      AnyKinMeasureOrg& L3L4 =.....BodyModel.Interface.Trunk.Spine.L3L4;
-      AnyKinMeasureOrg& L2L3 =.....BodyModel.Interface.Trunk.Spine.L2L3;
-      AnyKinMeasureOrg& L1L2 =.....BodyModel.Interface.Trunk.Spine.L1L2;
-      AnyKinMeasureOrg& T12L1 =.....BodyModel.Interface.Trunk.Spine.T12L1;
-      AnyKinMeasureOrg& T1C7 =.....BodyModel.Interface.Trunk.Spine.T1C7;
-      AnyKinMeasureOrg& C7C6 =.....BodyModel.Interface.Trunk.Spine.C7C6;
-      AnyKinMeasureOrg& C6C5 =.....BodyModel.Interface.Trunk.Spine.C6C5;
-      AnyKinMeasureOrg& C5C4 =.....BodyModel.Interface.Trunk.Spine.C5C4;
-      AnyKinMeasureOrg& C4C3 =.....BodyModel.Interface.Trunk.Spine.C4C3;
-      AnyKinMeasureOrg& C3C2 =.....BodyModel.Interface.Trunk.Spine.C3C2;
-      AnyKinMeasureOrg& C2C1 =.....BodyModel.Interface.Trunk.Spine.C2C1;
-      AnyKinMeasureOrg& C1C0 =.....BodyModel.Interface.Trunk.Spine.C1C0;
     };
-     OutDim=Input.nDim;
-     Coef = eye(OutDim);
-     Const ??= arrcat(.PelvisPosOffset, zeros(1,OutDim-3)[0]);
+    OutDim=3;
+    Coef = eye(3);
+    Const ??= .PelvisPosOffset;
   };
+  AnyKinMeasure& PelvisRotVec = ...BodyModel.Interface.Trunk.PelvisRotVec;
+  AnyKinMeasureOrg& SacrumPelvis = ...BodyModel.Interface.Trunk.Spine.SacrumPelvis;
+  AnyKinMeasureOrg& L5Sacrum =...BodyModel.Interface.Trunk.Spine.L5Sacrum;
+  AnyKinMeasureOrg& L4L5 =...BodyModel.Interface.Trunk.Spine.L4L5;
+  AnyKinMeasureOrg& L3L4 =...BodyModel.Interface.Trunk.Spine.L3L4;
+  AnyKinMeasureOrg& L2L3 =...BodyModel.Interface.Trunk.Spine.L2L3;
+  AnyKinMeasureOrg& L1L2 =...BodyModel.Interface.Trunk.Spine.L1L2;
+  AnyKinMeasureOrg& T12L1 =...BodyModel.Interface.Trunk.Spine.T12L1;
+  AnyKinMeasureOrg& T1C7 =...BodyModel.Interface.Trunk.Spine.T1C7;
+  AnyKinMeasureOrg& C7C6 =...BodyModel.Interface.Trunk.Spine.C7C6;
+  AnyKinMeasureOrg& C6C5 =...BodyModel.Interface.Trunk.Spine.C6C5;
+  AnyKinMeasureOrg& C5C4 =...BodyModel.Interface.Trunk.Spine.C5C4;
+  AnyKinMeasureOrg& C4C3 =...BodyModel.Interface.Trunk.Spine.C4C3;
+  AnyKinMeasureOrg& C3C2 =...BodyModel.Interface.Trunk.Spine.C3C2;
+  AnyKinMeasureOrg& C2C1 =...BodyModel.Interface.Trunk.Spine.C2C1;
+  AnyKinMeasureOrg& C1C0 =...BodyModel.Interface.Trunk.Spine.C1C0;
   Reaction.Type = repmat(nDim, Off);
 };
 


### PR DESCRIPTION
Improved how kinematics calculated in marker tracking is applied 
to inverse dynamics MoCap models. The previous
method for applying joint angles from marker tracking could sometimes
struggle with complex rotations (gimbal lock situations). The updated
implementation enhances the stability of the kinematic solver, particularly
for pelvis positioning, leading to more reliable motion analysis.

TL;DR: The implentation was previously using `AnyKinMeasureLinComb` to
allow for adding a pelvis offset. This had the side effect that the kinematic
solver had a diffculties handing solution close to gimbal locks (+/- pi
radians). The new implementation only includes the 3 pelvis positions in the
`AnyKinMeasureComb` instead of all trunk angles. This makes the kinematic
solver more robust and it is now able to handle gimbal locks better.
