### PR TITLE
feat(MoCap): Update JointAngleOutputs to include headers for output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   GIFs from being created when the video source was not an .mp4 file. It now
   supports any video format compatible with the ffmpeg library.
 
+### 🔧 Changed:
+* The intermediate joint angle files used in MoCap models now has headers which
+  reflects the original output measure. This is usefull if the files are used
+  for anything else that transfering the joint angles from marker trakcing to
+  inverse dynamics. 
+
+
 (ammr-3.1.2-changelog)=
 ## AMMR 3.1.2 (2025-06-02)
 [![Zenodo link](https://zenodo.org/badge/DOI/10.5281/zenodo.15534589.svg)](https://doi.org/10.5281/zenodo.15534589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
   for anything else that transfering the joint angles from marker trakcing to
   inverse dynamics. 
 
+### ➕ Added:
+
+* Two new outputs are added to the JointAngleOutputs folder in the
+  MarkerTracking study in MoCap models:
+
+  * JointAngleOutputs.AllDoFs.Values
+  * JointAngleOutputs.AllDoFs.Names
+
+  The variables contain values and names of all joint angle variables which are
+  saved when marker tracking runs. They provide a different way to get the same
+  intermediate joint angle values which AnyBody writes to files when running
+  marker trakcing.
+
+
 
 (ammr-3.1.2-changelog)=
 ## AMMR 3.1.2 (2025-06-02)

--- a/Tools/AnyMocap/JointAngleOutputs.any
+++ b/Tools/AnyMocap/JointAngleOutputs.any
@@ -186,8 +186,14 @@ AnyFolder JointAngleOutputs = {
   #endif
 
 #endif
-
-  AnyFloat AllDOF = Obj2NumFlatten(OutputFile_TrunkFull.Values);
-  AnyString AllHeaders = Obj2Str(OutputFile_TrunkFull.Values);
-
+  AnyFolder AllDoFs = {
+  AnyFloat Values = Obj2NumFlatten(flattenptr(ObjSearch(ObjGetParent(), "OutputFile*.Values")));
+    AnyStringArray Names = take(
+       arrcat(
+          Obj2StrFlatten(flattenptr(ObjSearch(ObjGetParent(),"OutputFile*.ColumnNames"))),
+          repmat(NumElemOf(Values),"")
+       ),
+       iarr(0, NumElemOf(Values)-1)
+    );
+  };
 }; //JointAngleOutputs

--- a/Tools/AnyMocap/JointAngleOutputs.any
+++ b/Tools/AnyMocap/JointAngleOutputs.any
@@ -1,179 +1,142 @@
+#class_template JointAngleOuputFile(__CLASS__ = AnyOutputFile){
+  #var FileName;
+  SepSign = ",";
+  Header = {
+    TitleSectionOnOff = Off;
+    ConstSectionOnOff = Off;
+    ConstSectionSaveOptionsOnOff = Off;
+    VarSectionOnOff = Off;
+    ShortenNamesOnOff = Off;
+  };
+};
 
 AnyFolder JointAngleOutputs = {
 
+  AnyString BaseName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName;
 
-
-  AnyOutputFile OutputFile_TrunkFull = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-rotvec-trunk-full.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector PelvisPosX = ..BodyModel.Interface.Trunk.PelvisPosX.Pos;
-    AnyVector PelvisPosY = ..BodyModel.Interface.Trunk.PelvisPosY.Pos;
-    AnyVector PelvisPosZ = ..BodyModel.Interface.Trunk.PelvisPosZ.Pos;
-
-    AnyVector PelvisRotVec = ..BodyModel.Interface.Trunk.PelvisRotVec.Pos;
-
-    AnyVector SacrumPelvis = ..BodyModel.Interface.Trunk.Spine.SacrumPelvis.Pos;
-    AnyVector L5Sacrum =..BodyModel.Interface.Trunk.Spine.L5Sacrum.Pos;
-    AnyVector L4L5 =..BodyModel.Interface.Trunk.Spine.L4L5.Pos;
-    AnyVector L3L4 =..BodyModel.Interface.Trunk.Spine.L3L4.Pos;
-    AnyVector L2L3 =..BodyModel.Interface.Trunk.Spine.L2L3.Pos;
-    AnyVector L1L2 =..BodyModel.Interface.Trunk.Spine.L1L2.Pos;
-    AnyVector T12L1 =..BodyModel.Interface.Trunk.Spine.T12L1.Pos;
-    AnyVector T1C7 =..BodyModel.Interface.Trunk.Spine.T1C7.Pos;
-    AnyVector C7C6 =..BodyModel.Interface.Trunk.Spine.C7C6.Pos;
-    AnyVector C6C5 =..BodyModel.Interface.Trunk.Spine.C6C5.Pos;
-    AnyVector C5C4 =..BodyModel.Interface.Trunk.Spine.C5C4.Pos;
-    AnyVector C4C3 =..BodyModel.Interface.Trunk.Spine.C4C3.Pos;
-    AnyVector C3C2 =..BodyModel.Interface.Trunk.Spine.C3C2.Pos;
-    AnyVector C2C1 =..BodyModel.Interface.Trunk.Spine.C2C1.Pos;
-    AnyVector C1C0 =..BodyModel.Interface.Trunk.Spine.C1C0.Pos;
-
+  JointAngleOuputFile OutputFile_TrunkFull =
+  {
+    FileName = .BaseName + "-rotvec-trunk-full.txt";
+//    AnyVector DOF = ..BodyModel.Interface.Trunk.DOFs.Pos;
+    Values = {
+      &..BodyModel.Interface.Trunk.PelvisPosX.Pos,
+      &..BodyModel.Interface.Trunk.PelvisPosY.Pos,
+      &..BodyModel.Interface.Trunk.PelvisPosZ.Pos,
+      &..BodyModel.Interface.Trunk.PelvisRotVec.Pos,
+      &..BodyModel.Interface.Trunk.Spine.SacrumPelvis.Pos,
+      &..BodyModel.Interface.Trunk.Spine.L5Sacrum.Pos,
+      &..BodyModel.Interface.Trunk.Spine.L4L5.Pos,
+      &..BodyModel.Interface.Trunk.Spine.L3L4.Pos,
+      &..BodyModel.Interface.Trunk.Spine.L2L3.Pos,
+      &..BodyModel.Interface.Trunk.Spine.L1L2.Pos,
+      &..BodyModel.Interface.Trunk.Spine.T12L1.Pos,
+      &..BodyModel.Interface.Trunk.Spine.T1C7.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C7C6.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C6C5.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C5C4.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C4C3.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C3C2.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C2C1.Pos,
+      &..BodyModel.Interface.Trunk.Spine.C1C0.Pos,
+    };
   };
 
 
-#if BM_LEG_LEFT & BM_LEG_MODEL_IS_TLEM
-  AnyOutputFile OutputFile_LeftLeg = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-left_leg_tlem.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-
-    AnyVector HipFlexion = ..BodyModel.Interface.Left.HipFlexion.Pos;
-    AnyVector HipAbduction = ..BodyModel.Interface.Left.HipAbduction.Pos;
-    AnyVector HipExternalRotation = ..BodyModel.Interface.Left.HipExternalRotation.Pos;
-    AnyVector KneeFlexion = ..BodyModel.Interface.Left.KneeFlexion.Pos;
-    AnyVector AnklePlantarFlexion = ..BodyModel.Interface.Left.AnklePlantarFlexion.Pos;
-    AnyVector SubTalarEversion = ..BodyModel.Interface.Left.SubTalarEversion.Pos;
-  };
-#endif
-
-
-
-#if BM_LEG_RIGHT & BM_LEG_MODEL_IS_TLEM
-  AnyOutputFile OutputFile_RightLeg = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-right_leg_tlem.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector HipFlexion = ..BodyModel.Interface.Right.HipFlexion.Pos;
-    AnyVector HipAbduction = ..BodyModel.Interface.Right.HipAbduction.Pos;
-    AnyVector HipExternalRotation = ..BodyModel.Interface.Right.HipExternalRotation.Pos;
-    AnyVector KneeFlexion = ..BodyModel.Interface.Right.KneeFlexion.Pos;
-    AnyVector AnklePlantarFlexion = ..BodyModel.Interface.Right.AnklePlantarFlexion.Pos;
-    AnyVector SubTalarEversion = ..BodyModel.Interface.Right.SubTalarEversion.Pos;
+#if BM_LEG_LEFT
+  JointAngleOuputFile OutputFile_LeftLeg =
+  {
+    #if BM_LEG_MODEL_IS_TLEM
+    FileName = .BaseName + "-euler-left_leg_tlem.txt";
+    Values = {
+      &..BodyModel.Interface.Left.HipFlexion.Pos,
+      &..BodyModel.Interface.Left.HipAbduction.Pos,
+      &..BodyModel.Interface.Left.HipExternalRotation.Pos,
+      &..BodyModel.Interface.Left.KneeFlexion.Pos,
+      &..BodyModel.Interface.Left.AnklePlantarFlexion.Pos,
+      &..BodyModel.Interface.Left.SubTalarEversion.Pos
+    };
+    #else
+    FileName = .BaseName + "-euler-left_leg.txt";
+    Values = {
+      &..BodyModel.Interface.Left.HipFlexion.Pos,
+      &..BodyModel.Interface.Left.HipAbduction.Pos,
+      &..BodyModel.Interface.Left.HipExternalRotation.Pos,
+      &..BodyModel.Interface.Left.KneeFlexion.Pos,
+      &..BodyModel.Interface.Left.AnklePlantarFlexion.Pos,
+      &..BodyModel.Interface.Left.AnkleEversion.Pos
+    };
+    #endif
   };
 #endif
 
 
-
-
-
-#if BM_LEG_LEFT & (BM_LEG_MODEL == _LEG_MODEL_LEG_)
-  AnyOutputFile OutputFile_LeftLeg = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-left_leg.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector HipFlexion = ..BodyModel.Interface.Left.HipFlexion.Pos;
-    AnyVector HipAbduction = ..BodyModel.Interface.Left.HipAbduction.Pos;
-    AnyVector HipExternalRotation = ..BodyModel.Interface.Left.HipExternalRotation.Pos;
-    AnyVector KneeFlexion = ..BodyModel.Interface.Left.KneeFlexion.Pos;
-    AnyVector AnklePlantarFlexion = ..BodyModel.Interface.Left.AnklePlantarFlexion.Pos;
-    AnyVector AnkleEversion = ..BodyModel.Interface.Left.AnkleEversion.Pos;
+#if BM_LEG_RIGHT
+  JointAngleOuputFile OutputFile_RightLeg =
+  {
+    #if BM_LEG_MODEL_IS_TLEM
+    FileName = .BaseName + "-euler-right_leg_tlem.txt";
+    Values = {
+      &..BodyModel.Interface.Right.HipFlexion.Pos,
+      &..BodyModel.Interface.Right.HipAbduction.Pos,
+      &..BodyModel.Interface.Right.HipExternalRotation.Pos,
+      &..BodyModel.Interface.Right.KneeFlexion.Pos,
+      &..BodyModel.Interface.Right.AnklePlantarFlexion.Pos,
+      &..BodyModel.Interface.Right.SubTalarEversion.Pos
+    };
+    #else
+    FileName = TEMP_PATH+"/"+ BaseName + "-euler-right_leg.txt";
+    Values = {
+      &..BodyModel.Interface.Right.HipFlexion.Pos,
+      &..BodyModel.Interface.Right.HipAbduction.Pos,
+      &..BodyModel.Interface.Right.HipExternalRotation.Pos,
+      &..BodyModel.Interface.Right.KneeFlexion.Pos,
+      &..BodyModel.Interface.Right.AnklePlantarFlexion.Pos,
+      &..BodyModel.Interface.Right.AnkleEversion.Pos
+    };
+    #endif
   };
 #endif
-
-
-
-#if BM_LEG_RIGHT & (BM_LEG_MODEL == _LEG_MODEL_LEG_)
-  AnyOutputFile OutputFile_RightLeg = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-right_leg.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector HipFlexion = ..BodyModel.Interface.Right.HipFlexion.Pos;
-    AnyVector HipAbduction = ..BodyModel.Interface.Right.HipAbduction.Pos;
-    AnyVector HipExternalRotation = ..BodyModel.Interface.Right.HipExternalRotation.Pos;
-    AnyVector KneeFlexion = ..BodyModel.Interface.Right.KneeFlexion.Pos;
-    AnyVector AnklePlantarFlexion = ..BodyModel.Interface.Right.AnklePlantarFlexion.Pos;
-    AnyVector AnkleEversion = ..BodyModel.Interface.Right.AnkleEversion.Pos;
-  };
-#endif
-
 
 
 
 #if BM_ARM_LEFT == ON
 
-
-  AnyOutputFile OutputFile_LeftArm = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX +MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-rotvec-left_arm_shoulder.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector ThoraxClavicula =..BodyModel.Interface.Left.RotVectorMeasures.ThoraxClavicula.Pos;
-    AnyVector ClaviculaScapula =..BodyModel.Interface.Left.RotVectorMeasures.ClaviculaScapula.Pos;
-    AnyVector ScapulaHumerus =..BodyModel.Interface.Left.RotVectorMeasures.ScapulaHumerus.Pos;
-    AnyVector HumerusUlna =..BodyModel.Interface.Left.ElbowFlexion.Pos;
-    AnyVector UlnaRadius =..BodyModel.Interface.Left.ElbowPronation.Pos;
-    AnyVector RadiusWrist =..BodyModel.Interface.Left.WristFlexion.Pos;
-    AnyVector WristHand =..BodyModel.Interface.Left.WristAbduction.Pos;
+  JointAngleOuputFile OutputFile_LeftArm =
+  {
+    FileName = .BaseName + "-rotvec-left_arm_shoulder.txt";
+    Values = {
+      &..BodyModel.Interface.Left.RotVectorMeasures.ThoraxClavicula,
+      &..BodyModel.Interface.Left.RotVectorMeasures.ClaviculaScapula,
+      &..BodyModel.Interface.Left.RotVectorMeasures.ScapulaHumerus,
+      &..BodyModel.Interface.Left.ElbowFlexion,
+      &..BodyModel.Interface.Left.ElbowPronation,
+      &..BodyModel.Interface.Left.WristFlexion,
+      &..BodyModel.Interface.Left.WristAbduction
+    };
   };
 
-
   #if BM_ARM_DETAILED_HAND
-  AnyOutputFile OutputFile_LeftDetailedHand = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-left_detailed_hand.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector CMC1Flexion = ..BodyModel.Interface.Left.CMCFlexion.Pos;
-    AnyVector CMC1Abduction = ..BodyModel.Interface.Left.CMCAbduction.Pos;
-    AnyVector MCP1Flexion = ..BodyModel.Interface.Left.MCPFlexion.Pos;
-    AnyVector MCP1Abduction = ..BodyModel.Interface.Left.MCPAbduction.Pos;
-    AnyVector DIP1 = ..BodyModel.Interface.Left.DIP.Pos;
-    AnyVector MCP2 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.MCP.Pos;
-    AnyVector PIP2 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.PIP.Pos;
-    AnyVector DIP2 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.DIP.Pos;
-    AnyVector MCP3 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.MCP.Pos;
-    AnyVector PIP3 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.PIP.Pos;
-    AnyVector DIP3 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.DIP.Pos;
-    AnyVector MCP4 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.MCP.Pos;
-    AnyVector PIP4 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.PIP.Pos;
-    AnyVector DIP4 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.DIP.Pos;
-    AnyVector MCP5 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.MCP.Pos;
-    AnyVector PIP5 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.PIP.Pos;
-    AnyVector DIP5 = ..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.DIP.Pos;
+  JointAngleOuputFile OutputFile_LeftDetailedHand = {
+    FileName = .BaseName + "-euler-left_detailed_hand.txt";
+    Values = {
+      &..BodyModel.Interface.Left.CMCFlexion.Pos,
+      &..BodyModel.Interface.Left.CMCAbduction.Pos,
+      &..BodyModel.Interface.Left.MCPFlexion.Pos,
+      &..BodyModel.Interface.Left.MCPAbduction.Pos,
+      &..BodyModel.Interface.Left.DIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.MCP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.PIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger2.Jnt.DIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.MCP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.PIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger3.Jnt.DIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.MCP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.PIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger4.Jnt.DIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.MCP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.PIP.Pos,
+      &..BodyModel.Left.ShoulderArm.Seg.Hand.Finger5.Jnt.DIP.Pos
+    };
   };
   #endif
 
@@ -182,56 +145,49 @@ AnyFolder JointAngleOutputs = {
 
 #if BM_ARM_RIGHT == ON
 
-  AnyOutputFile OutputFile_RightArm = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-rotvec-right_arm_shoulder.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
+  JointAngleOuputFile OutputFile_RightArm = {
+    FileName = .BaseName + "-rotvec-right_arm_shoulder.txt";
+    Values = {
+      &..BodyModel.Interface.Right.RotVectorMeasures.ThoraxClavicula,
+      &..BodyModel.Interface.Right.RotVectorMeasures.ClaviculaScapula,
+      &..BodyModel.Interface.Right.RotVectorMeasures.ScapulaHumerus,
+      &..BodyModel.Interface.Right.ElbowFlexion,
+      &..BodyModel.Interface.Right.ElbowPronation,
+      &..BodyModel.Interface.Right.WristFlexion,
+      &..BodyModel.Interface.Right.WristAbduction
 
-    AnyVector ThoraxClavicula =..BodyModel.Interface.Right.RotVectorMeasures.ThoraxClavicula.Pos;
-    AnyVector ClaviculaScapula =..BodyModel.Interface.Right.RotVectorMeasures.ClaviculaScapula.Pos;
-    AnyVector ScapulaHumerus =..BodyModel.Interface.Right.RotVectorMeasures.ScapulaHumerus.Pos;
-    AnyVector HumerusUlna =..BodyModel.Interface.Right.ElbowFlexion.Pos;
-    AnyVector UlnaRadius =..BodyModel.Interface.Right.ElbowPronation.Pos;
-    AnyVector RadiusWrist =..BodyModel.Interface.Right.WristFlexion.Pos;
-    AnyVector WristHand =..BodyModel.Interface.Right.WristAbduction.Pos;
+    };
   };
-
 
   #if BM_ARM_DETAILED_HAND
-  AnyOutputFile OutputFile_RightDetailedHand = {
-    FileName = TEMP_PATH+"/"+ MOCAP_TEST_FILENAME_PREFIX + MOCAP_OUTPUT_FILENAME_PREFIX + Main.ModelSetup.TrialSpecificData.TrialFileName + "-euler-right_detailed_hand.txt";
-    SepSign = ",";
-    SepSpaceAutoOnOff = Off;
-    Header.TitleSectionOnOff = Off;
-    Header.ConstSectionOnOff = Off;
-    Header.ConstSectionSaveOptionsOnOff = Off;
-    Header.VarSectionOnOff = Off;
-
-    AnyVector CMC1Flexion = ..BodyModel.Interface.Right.CMCFlexion.Pos;
-    AnyVector CMC1Abduction = ..BodyModel.Interface.Right.CMCAbduction.Pos;
-    AnyVector MCP1Flexion = ..BodyModel.Interface.Right.MCPFlexion.Pos;
-    AnyVector MCP1Abduction = ..BodyModel.Interface.Right.MCPAbduction.Pos;
-    AnyVector DIP1 = ..BodyModel.Interface.Right.DIP.Pos;
-    AnyVector MCP2 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.MCP.Pos;
-    AnyVector PIP2 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.PIP.Pos;
-    AnyVector DIP2 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.DIP.Pos;
-    AnyVector MCP3 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.MCP.Pos;
-    AnyVector PIP3 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.PIP.Pos;
-    AnyVector DIP3 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.DIP.Pos;
-    AnyVector MCP4 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.MCP.Pos;
-    AnyVector PIP4 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.PIP.Pos;
-    AnyVector DIP4 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.DIP.Pos;
-    AnyVector MCP5 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.MCP.Pos;
-    AnyVector PIP5 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.PIP.Pos;
-    AnyVector DIP5 = ..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.DIP.Pos;
+  JointAngleOuputFile OutputFile_RightDetailedHand = {
+    FileName = .BaseName + "-euler-right_detailed_hand.txt";
+    Values = {
+      &..BodyModel.Interface.Right.CMCFlexion.Pos,
+      &..BodyModel.Interface.Right.CMCAbduction.Pos,
+      &..BodyModel.Interface.Right.MCPFlexion.Pos,
+      &..BodyModel.Interface.Right.MCPAbduction.Pos,
+      &..BodyModel.Interface.Right.DIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.MCP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.PIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger2.Jnt.DIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.MCP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.PIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger3.Jnt.DIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.MCP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.PIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger4.Jnt.DIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.MCP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.PIP.Pos,
+      &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.DIP.Pos
+    };
   };
+  
   #endif
 
 #endif
 
+  AnyFloat AllDOF = Obj2NumFlatten(OutputFile_TrunkFull.Values);
+  AnyString AllHeaders = Obj2Str(OutputFile_TrunkFull.Values);
 
 }; //JointAngleOutputs

--- a/Tools/AnyMocap/JointAngleOutputs.any
+++ b/Tools/AnyMocap/JointAngleOutputs.any
@@ -188,12 +188,15 @@ AnyFolder JointAngleOutputs = {
 #endif
   AnyFolder AllDoFs = {
   AnyFloat Values = Obj2NumFlatten(flattenptr(ObjSearch(ObjGetParent(), "OutputFile*.Values")));
-    AnyStringArray Names = take(
+#if (ANYBODY_V1 > 8) | (ANYBODY_V1 == 8 & ANYBODY_V2 > 1) | (ANYBODY_V1 == 8 & ANYBODY_V2 == 1 & ANYBODY_V3 > 2 )
+  // Exporting the names of the variables requires a feature in AMS 8.1.3
+  AnyStringArray Names = take(
        arrcat(
           Obj2StrFlatten(flattenptr(ObjSearch(ObjGetParent(),"OutputFile*.ColumnNames"))),
           repmat(NumElemOf(Values),"")
        ),
        iarr(0, NumElemOf(Values)-1)
     );
+#endif
   };
 }; //JointAngleOutputs

--- a/Tools/AnyMocap/JointAngleOutputs.any
+++ b/Tools/AnyMocap/JointAngleOutputs.any
@@ -105,13 +105,13 @@ AnyFolder JointAngleOutputs = {
   {
     FileName = .BaseName + "-rotvec-left_arm_shoulder.txt";
     Values = {
-      &..BodyModel.Interface.Left.RotVectorMeasures.ThoraxClavicula,
-      &..BodyModel.Interface.Left.RotVectorMeasures.ClaviculaScapula,
-      &..BodyModel.Interface.Left.RotVectorMeasures.ScapulaHumerus,
-      &..BodyModel.Interface.Left.ElbowFlexion,
-      &..BodyModel.Interface.Left.ElbowPronation,
-      &..BodyModel.Interface.Left.WristFlexion,
-      &..BodyModel.Interface.Left.WristAbduction
+      &..BodyModel.Interface.Left.RotVectorMeasures.ThoraxClavicula.Pos,
+      &..BodyModel.Interface.Left.RotVectorMeasures.ClaviculaScapula.Pos,
+      &..BodyModel.Interface.Left.RotVectorMeasures.ScapulaHumerus.Pos,
+      &..BodyModel.Interface.Left.ElbowFlexion.Pos,
+      &..BodyModel.Interface.Left.ElbowPronation.Pos,
+      &..BodyModel.Interface.Left.WristFlexion.Pos,
+      &..BodyModel.Interface.Left.WristAbduction.Pos,
     };
   };
 
@@ -148,13 +148,13 @@ AnyFolder JointAngleOutputs = {
   JointAngleOuputFile OutputFile_RightArm = {
     FileName = .BaseName + "-rotvec-right_arm_shoulder.txt";
     Values = {
-      &..BodyModel.Interface.Right.RotVectorMeasures.ThoraxClavicula,
-      &..BodyModel.Interface.Right.RotVectorMeasures.ClaviculaScapula,
-      &..BodyModel.Interface.Right.RotVectorMeasures.ScapulaHumerus,
-      &..BodyModel.Interface.Right.ElbowFlexion,
-      &..BodyModel.Interface.Right.ElbowPronation,
-      &..BodyModel.Interface.Right.WristFlexion,
-      &..BodyModel.Interface.Right.WristAbduction
+      &..BodyModel.Interface.Right.RotVectorMeasures.ThoraxClavicula.Pos,
+      &..BodyModel.Interface.Right.RotVectorMeasures.ClaviculaScapula.Pos,
+      &..BodyModel.Interface.Right.RotVectorMeasures.ScapulaHumerus.Pos,
+      &..BodyModel.Interface.Right.ElbowFlexion.Pos,
+      &..BodyModel.Interface.Right.ElbowPronation.Pos,
+      &..BodyModel.Interface.Right.WristFlexion.Pos,
+      &..BodyModel.Interface.Right.WristAbduction.Pos,
 
     };
   };


### PR DESCRIPTION
The intermediate joint angle files used in MoCap models now has headers which reflects the original output measure. This is useful when using the files for other purposes, as they headers now reflect the measure from which they come.

Previously the headers would have been: 
```
Main.Studies.MarkerTracking.JointAngleOutputs.OutputFile_TrunkFull.PelvisPosX
```

Now they instead point to the original values: 
```
"Main.HumanModel.BodyModel.Interface.Trunk.PelvisPosX.Pos", "Main.HumanModel.BodyModel.Interface.Trunk.PelvisPosY.Pos", "Main.HumanModel.BodyModel.Interface.Trunk.PelvisPosZ.Pos", "Main.HumanModel.BodyModel.Interface.Trunk.PelvisRotVec.Pos[0]", "Main.HumanModel.BodyModel.Interface.Trunk.PelvisRotVec.Pos[1]", 
```

Also, two new outputs are added to the JointAngleOutputs folder in the MarkerTracking study in MoCap models:

  * `JointAngleOutputs.AllDoFs.Values`
  * `JointAngleOutputs.AllDoFs.Names`

The variables contain values and names of all joint angle variables which are saved when marker tracking runs. They provide a different way to get the same intermediate joint angle values which AnyBody writes to files when running marker tracking. E.g. when exporting the data directly to Python via the AnyPyTools library.

Note: Exporting the Names of the variables is only enabled when running AMS > 8.1.3, since it requires a new member variable in AnyOutputFile called (CollumnNames)