### PR TITLE
feat(mocap): option to save all intermediate mocap driver values/names from MarkerTracking or InverseDynamics 

### DIFF
--- a/Tests/AnyMocap/Test_JointAngleInputOutput.any
+++ b/Tests/AnyMocap/Test_JointAngleInputOutput.any
@@ -1,0 +1,53 @@
+//ignore_errors = ["'Set Value' operation on"]
+//fatal_warnings = True
+
+
+// This test ensures that the same drivers are used as output in MarkerTracking 
+// and input for InverseDynamics. The test also assumes that the drivers comes in
+// the same order, eventhough that is not strictly necessary since joint angles are
+// split among different files. 
+
+
+#include "../libdef.any"
+
+#path MOCAP_PATH_MAINFILEDIR "<ANYMOCAP_EXAMPLES>/Plug-in-gait_Simple"
+#path MOCAP_PATH_MAINFILE "<MOCAP_PATH_MAINFILEDIR>/FullBody.main.any"
+#define MOCAP_NAME_MAINFILEDIR "Plug-in-gait_Simple"
+
+#path TEMP_PATH "Output/"
+
+
+#include "<MOCAP_PATH_MAINFILE>"
+
+Main =
+{
+  AnyOperationSequence  RunTest =
+  {
+    AnyOperation& MarkerTracking = Main.Studies.MarkerTracking.InitialConditions;
+  };
+  
+  
+  Main.Studies.MarkerTracking = 
+  {
+     AnyInt ModelNotRunCheck = eqfun(System.LoadedModel.ActiveMechStudy, None);
+       
+    AnyInt EqualHeadersCheck = eqfun(
+          Main.Studies.MarkerTracking.JointAngleOutputs.AllDoFs.HeaderNames,
+          Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.AllDoFs.HeaderNames
+     );
+     
+   AnyInt IndenticalNumberOfDriversCheck = assert(
+      eqfun(
+        NumElemOf(Main.Studies.MarkerTracking.JointAngleOutputs.AllDoFs.HeaderNames), 
+        NumElemOf(Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.AllDoFs.HeaderNames), 
+      )
+   );
+  
+    AnyInt IdenticalInputOuptutCheck = assert(
+//      orfun(ModelNotRunCheck, andfun(EqualHeadersCheck, IndenticalNumberOfDriversCheck) ),
+      orfun(ModelNotRunCheck, IndenticalNumberOfDriversCheck ),
+      "Output joint angles in marker tracking does not match joint angles driven in Invers dynamics."
+    );
+  };
+
+};

--- a/Tests/AnyMocap/Test_JointAngleInputOutput.any
+++ b/Tests/AnyMocap/Test_JointAngleInputOutput.any
@@ -2,10 +2,10 @@
 //fatal_warnings = True
 
 
-// This test ensures that the same drivers are used as output in MarkerTracking 
+// This test ensures that the same drivers are used as output in MarkerTracking
 // and input for InverseDynamics. The test also assumes that the drivers comes in
 // the same order, eventhough that is not strictly necessary since joint angles are
-// split among different files. 
+// split among different files.
 
 
 #include "../libdef.any"
@@ -25,29 +25,30 @@ Main =
   {
     AnyOperation& MarkerTracking = Main.Studies.MarkerTracking.InitialConditions;
   };
-  
-  
-  Main.Studies.MarkerTracking = 
+
+#if (ANYBODY_V1 > 8) | (ANYBODY_V1 == 8 & ANYBODY_V2 > 1) | (ANYBODY_V1 == 8 & ANYBODY_V2 == 1 & ANYBODY_V3 > 2 )
+  Main.Studies.MarkerTracking =
   {
      AnyInt ModelNotRunCheck = eqfun(System.LoadedModel.ActiveMechStudy, None);
-       
+
     AnyInt EqualHeadersCheck = eqfun(
           Main.Studies.MarkerTracking.JointAngleOutputs.AllDoFs.HeaderNames,
           Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.AllDoFs.HeaderNames
      );
-     
+
    AnyInt IndenticalNumberOfDriversCheck = assert(
       eqfun(
-        NumElemOf(Main.Studies.MarkerTracking.JointAngleOutputs.AllDoFs.HeaderNames), 
-        NumElemOf(Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.AllDoFs.HeaderNames), 
+        NumElemOf(Main.Studies.MarkerTracking.JointAngleOutputs.AllDoFs.HeaderNames),
+        NumElemOf(Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.AllDoFs.HeaderNames),
       )
    );
-  
+
     AnyInt IdenticalInputOuptutCheck = assert(
 //      orfun(ModelNotRunCheck, andfun(EqualHeadersCheck, IndenticalNumberOfDriversCheck) ),
       orfun(ModelNotRunCheck, IndenticalNumberOfDriversCheck ),
       "Output joint angles in marker tracking does not match joint angles driven in Invers dynamics."
     );
   };
+#endif
 
 };

--- a/Tools/AnyMocap/ClassTemplates.any
+++ b/Tools/AnyMocap/ClassTemplates.any
@@ -15,5 +15,6 @@
  #include "<ANYBODY_PATH_AMMR>/Tools/GRFPrediction/FootPlateConditionalContact.any"
  #include "<ANYBODY_PATH_MODELUTILS>/KinematicLimits/RangeOfMotionLimits_template.any"
  #include "<ANYBODY_PATH_MODELUTILS>/EMGProcessing/CreateEMGEnvelope.any"
+ #include "CollectDriverValuesTemplate.any"
 
 #endif

--- a/Tools/AnyMocap/CollectDriverValuesTemplate.any
+++ b/Tools/AnyMocap/CollectDriverValuesTemplate.any
@@ -1,0 +1,27 @@
+#ifndef _ANYMOCAP_COLLECT_DRIVER_VALUES_ANY_
+#define _ANYMOCAP_COLLECT_DRIVER_VALUES_ANY_
+
+
+#class_template CollectDriverValues(
+SEARCH_DRIVERS = "Main.Studies.InverseDynamicStudy.ModelEnvironmentConnection.JointsAndDrivers.JntDriver*.DriverPos",
+HEADER_PREFIX = "",
+) {    
+  #var AnyStringVar HeaderPrefix = HEADER_PREFIX;
+  #var AnyObjectPtr Drivers = ObjSearch(SEARCH_DRIVERS);
+  AnyFloat Values = Obj2NumFlatten(flattenptr(Drivers));
+  #var AnyStringArray HeaderNames = 
+     repmat(NumElemOf(Values), HeaderPrefix)
+     + Obj2StrFlatten(ObjRefResolve(ObjGetMember(
+         ObjGetParent(flattenptr(Drivers)),
+         "KinMeasureArr"
+         )))
+     + repmat(NumElemOf(Values), ".Pos[")
+     + strval(round(Obj2NumFlatten(ObjRefResolve(ObjGetMember(
+         ObjGetParent(flattenptr(Drivers)),
+         "KinMeasureIndexArr"
+         )))))
+     + repmat(NumElemOf(Values), "]");
+};
+
+  
+#endif

--- a/Tools/AnyMocap/JointAngleOutputs.any
+++ b/Tools/AnyMocap/JointAngleOutputs.any
@@ -182,21 +182,24 @@ AnyFolder JointAngleOutputs = {
       &..BodyModel.Right.ShoulderArm.Seg.Hand.Finger5.Jnt.DIP.Pos
     };
   };
-  
+
   #endif
 
 #endif
-  AnyFolder AllDoFs = {
-  AnyFloat Values = Obj2NumFlatten(flattenptr(ObjSearch(ObjGetParent(), "OutputFile*.Values")));
+
 #if (ANYBODY_V1 > 8) | (ANYBODY_V1 == 8 & ANYBODY_V2 > 1) | (ANYBODY_V1 == 8 & ANYBODY_V2 == 1 & ANYBODY_V3 > 2 )
-  // Exporting the names of the variables requires a feature in AMS 8.1.3
-  AnyStringArray Names = take(
+AnyFolder   AllDoFs = {
+  AnyStringVar HeaderPrefix ??= "DOF:";
+  AnyFloat Values = Obj2NumFlatten(flattenptr(ObjSearch(ObjGetParent(), "OutputFile*.Values")));
+  AnyStringArray HeaderNames = take(
        arrcat(
+          repmat(NumElemOf(Obj2StrFlatten(flattenptr(ObjSearch(ObjGetParent(),"OutputFile*.ColumnNames")))), HeaderPrefix) +
           Obj2StrFlatten(flattenptr(ObjSearch(ObjGetParent(),"OutputFile*.ColumnNames"))),
           repmat(NumElemOf(Values),"")
        ),
        iarr(0, NumElemOf(Values)-1)
     );
+};
 #endif
-  };
+
 }; //JointAngleOutputs

--- a/Tools/AnyMocap/JointsAndDriversOptimized.any
+++ b/Tools/AnyMocap/JointsAndDriversOptimized.any
@@ -26,17 +26,25 @@ AnyKinDriver JntDriverTrunkFull = {
            },repmat(nDim-6,0.0)
     )
   );
-  AnyVector PelvisPosOffset ??= {0,0,0};
-  AnyKinMeasureLinComb PelvisPos = {
-    AnyKinMeasureOrg Input = {
-      AnyKinMeasure& PelvisPosX = .....BodyModel.Interface.Trunk.PelvisPosX;
-      AnyKinMeasure& PelvisPosY = .....BodyModel.Interface.Trunk.PelvisPosY;
-      AnyKinMeasure& PelvisPosZ = .....BodyModel.Interface.Trunk.PelvisPosZ;
+  #ifdef ANYMOCAP_PELVIS_DRIVER_OFFSET
+    // Sepcial feature for overridding the pelvis position. 
+    // This is not enable by default
+    AnyVector PelvisPosOffset ??= {0,0,0};
+    AnyKinMeasureLinComb PelvisPos = {
+      AnyKinMeasureOrg Input = {
+        AnyKinMeasure& PelvisPosX = .....BodyModel.Interface.Trunk.PelvisPosX;
+        AnyKinMeasure& PelvisPosY = .....BodyModel.Interface.Trunk.PelvisPosY;
+        AnyKinMeasure& PelvisPosZ = .....BodyModel.Interface.Trunk.PelvisPosZ;
+      };
+      OutDim=3;
+      Coef = eye(3);
+      Const ??= .PelvisPosOffset;
     };
-    OutDim=3;
-    Coef = eye(3);
-    Const ??= .PelvisPosOffset;
-  };
+  #else
+  AnyKinMeasure& PelvisPosX = ...BodyModel.Interface.Trunk.PelvisPosX;
+  AnyKinMeasure& PelvisPosY = ...BodyModel.Interface.Trunk.PelvisPosY;
+  AnyKinMeasure& PelvisPosZ = ...BodyModel.Interface.Trunk.PelvisPosZ;
+  #endif
   AnyKinMeasure& PelvisRotVec = ...BodyModel.Interface.Trunk.PelvisRotVec;
   AnyKinMeasureOrg& SacrumPelvis = ...BodyModel.Interface.Trunk.Spine.SacrumPelvis;
   AnyKinMeasureOrg& L5Sacrum =...BodyModel.Interface.Trunk.Spine.L5Sacrum;

--- a/Tools/AnyMocap/JointsAndDriversOptimized.any
+++ b/Tools/AnyMocap/JointsAndDriversOptimized.any
@@ -27,7 +27,7 @@ AnyKinDriver JntDriverTrunkFull = {
     )
   );
   #ifdef ANYMOCAP_PELVIS_DRIVER_OFFSET
-    // Sepcial feature for overridding the pelvis position. 
+    // Special feature for overriding the pelvis position.
     // This is not enable by default
     AnyVector PelvisPosOffset ??= {0,0,0};
     AnyKinMeasureLinComb PelvisPos = {
@@ -229,6 +229,9 @@ AnyKinDriver JntDriverTrunkFull = {
 
   #endif
 
+  // Collect all the driver values and names in single variables which can
+  // more easily be saved or exported.
+  CollectDriverValues AllDoFs(HEADER_PREFIX="DOF:") = { };
 
 
 };


### PR DESCRIPTION
This feature is targeted the statistical walking models. It will make much easier to save the output from a model and then recreate the fourier drivers later. 

This also adds a test that the drivers are identical between Marker tracking output and Inverse dynamics intput. The full test can first be enabled when the #771 is merged and released with AMS