### PR TITLE
fix: Bugfix leg press machine model

### DIFF
--- a/Application/Examples/LegPressMachine/Model/BackrestSupport.any
+++ b/Application/Examples/LegPressMachine/Model/BackrestSupport.any
@@ -659,7 +659,7 @@ AnyFolder BackrestSupport = {
 
   AnyVar CC_Radius = max({Main.Parameters.DesignParameters.Back_Rest_Width/2,
                           Main.Parameters.DesignParameters.Back_Rest_Height/2}) ;
-  AnyVar CC_LimitLow = -Main.Parameters.DesignParameters.Back_Rest_Thick/2;
+  AnyVar CC_LimitLow = -Main.Parameters.DesignParameters.Back_Rest_Thick;
   AnyVar CC_LimitHigh = Main.Parameters.DesignParameters.Back_Rest_Thick/2;
   AnyRefFrame& CC_Base_Frame = Main.Model.EnvironmentModel.Segs.Back_Rest.cc_base_node;
   AnyIntArray CC_Direction = {1,2,0};

--- a/Application/Examples/LegPressMachine/Model/FootrestSupport.any
+++ b/Application/Examples/LegPressMachine/Model/FootrestSupport.any
@@ -7,7 +7,7 @@ AnyFolder FootSupport =
   AnyVar CC_Radius = 2.0*max({Main.Parameters.DesignParameters.Foot_Rest_Width/2,
                           Main.Parameters.DesignParameters.Foot_Rest_Height/2}) ;
   AnyVar CC_LimitLow = -Main.Parameters.DesignParameters.Foot_Rest_Thick;
-  AnyVar CC_LimitHigh = Main.Parameters.DesignParameters.Foot_Rest_Thick/2 * 0.001;
+  AnyVar CC_LimitHigh = Main.Parameters.DesignParameters.Foot_Rest_Thick/2;
 
   AnySeg VFPlate_Left=
   {
@@ -477,6 +477,15 @@ AnyFolder FootSupport =
   {
     AnyRefFrame &BaseObject = .VFPlate_Left;
     AnyRefFrame &TargetObject =....BodyModel.Left.Leg.Seg.Foot.ToeMedialContactNode;
+
+    TargetObject =
+    {
+      AnyDrawNode  drw=
+      {
+        ScaleXYZ={0.005,.005,.005};
+        RGB={0,0,1};
+      };
+    };
 
     AnyRefFrame &StrengthObject=TargetObject; //Node used for strength measurement, occasionally this is different from the target object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
    share the same marker protocol irrespectively of if the detailed or simple
    hand is enabled. 
 *  Fixed arm rest asymmetry in various sitting model application examples. 
+*  Fixed contact thresholds in {ref}`Leg Press Machine 
+   example<example_legpressmachinemodel>` to ensure contact with all the nodes.
 
 ### ➕ Added:
 * The implemenation of the pelvis rotation vector measure in the interface folder has been refactored to allow overwritting the global reference frame.

--- a/Docs/Applications/Sports/LegPressMachine.md
+++ b/Docs/Applications/Sports/LegPressMachine.md
@@ -4,7 +4,7 @@ gallery_image: "/Applications/images/LegPressMachine.webp"
 ---
 
 (sphx_glr_auto_examples_Sports_plot_LegPressMachine.py)=
-
+(example_legpressmachinemodel)=
 # Leg Press Machine
 
 ````{sidebar} **Example**


### PR DESCRIPTION
The contact thresholds are updated to ensure contact with all the nodes. Currently T10 support and foot right/left 4 are not within the contact threshold.
Changelog entry is added