### PR TITLE
feat: More robust check for if Python is available

### DIFF
--- a/Body/AAUHuman/HumanModel.defs.any
+++ b/Body/AAUHuman/HumanModel.defs.any
@@ -22,18 +22,26 @@ Error("ANYBODY_PATH_TOOLBOX is deprecated. Use ANYBODY_PATH_MODELUTILS instead")
 
 
 #define ANYBODY_PYTHON_AVAILABLE 0
-#define ANYBODY_BUILTIN_PYTHON_AVAILABLE 0
-
 #ifdef ANYBODY_PATH_PYTHONHOME
-#ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
-#undef ANYBODY_PYTHON_AVAILABLE
-#define ANYBODY_PYTHON_AVAILABLE 1
-#endif
+  #ifpathexists "<ANYBODY_PATH_PYTHONHOME>/python.exe"
+    #undef ANYBODY_PYTHON_AVAILABLE
+    #define ANYBODY_PYTHON_AVAILABLE 1
+  #endif
 #endif
 
-#ifpathexists "<ANYBODY_PATH_INSTALLDIR>/Python/python.exe"
-#undef ANYBODY_PYTHON_AVAILABLE
-#undef ANYBODY_BUILTIN_PYTHON_AVAILABLE
-#define ANYBODY_PYTHON_AVAILABLE 1
-#define ANYBODY_BUILTIN_PYTHON_AVAILABLE 1
+// Check for built-in Python (shipped with AnyBody, or part of the AnyBody conda package)
+#ifndef ANYBODY_BUILTIN_PYTHON_AVAILABLE
+  #define ANYBODY_BUILTIN_PYTHON_AVAILABLE 0
+  #ifpathexists "<ANYBODY_PATH_EXEDIR>/Python/python.exe"
+    #undef ANYBODY_PYTHON_AVAILABLE
+    #undef ANYBODY_BUILTIN_PYTHON_AVAILABLE
+    #define ANYBODY_PYTHON_AVAILABLE 1
+    #define ANYBODY_BUILTIN_PYTHON_AVAILABLE 1
+  #endif
+  #ifpathexists "<ANYBODY_PATH_EXEDIR>/../python.exe"
+    #undef ANYBODY_PYTHON_AVAILABLE
+    #undef ANYBODY_BUILTIN_PYTHON_AVAILABLE
+    #define ANYBODY_PYTHON_AVAILABLE 1
+    #define ANYBODY_BUILTIN_PYTHON_AVAILABLE 1
+  #endif
 #endif


### PR DESCRIPTION
This feature will also allow us to set 
```
#define ANYBODY_BUILTIN_PYTHON_AVAILABLE OFF
```
Which will prevent AMMR from using python hooks, unless the explicit `ANYBODY_PATH_PYTHONHOME` environment variable is set. 