### PR TITLE
feat: Refactor libdef system, to more easily include the Human Model

### DIFF
--- a/AMMR.version.any
+++ b/AMMR.version.any
@@ -5,6 +5,8 @@
 #define AMMR_VERSION_PATCH 4
 #endif
 
+#define ANYBODY_APPLICATION_LIBRARY_NAME "AMMR" + AMMR_VERSION
+
 #if (ANYBODY_V1 < 8) | (ANYBODY_V1 == 8 & ANYBODY_V2 < 0) | (ANYBODY_V1 == 8 & ANYBODY_V2 == 0 & ANYBODY_V4 < 10984 )
 //
 // This model repository needs at least AnyBody version 8.0 to load correctly.

--- a/Body/AAUHuman/HumanModel.any
+++ b/Body/AAUHuman/HumanModel.any
@@ -1,3 +1,6 @@
+
+#include "../../libdef.any"
+
 #ifndef ANYBODY_PATH_BODY_GENERICBODYMODEL
   #path ANYBODY_PATH_BODY_GENERICBODYMODEL "<ANYBODY_PATH_BODY>\BodyModels\GenericBodyModel\"
 #endif

--- a/Body/AAUHuman/HumanModel.defs.any
+++ b/Body/AAUHuman/HumanModel.defs.any
@@ -1,3 +1,49 @@
+// This files configures and number of global switches/variables
+// used by the human model.
+
+#ifndef _HUMAN_MODEL_DEFINES_
+#define _HUMAN_MODEL_DEFINES_
+
+#ifndef ANYBODY_PATH_AMMR
+#path ANYBODY_PATH_AMMR "../../"
+#endif
+
+#ifndef ANYBODY_HUMAN_MODEL
+#path ANYBODY_HUMAN_MODEL "HumanModel.any"
+#endif
+
+#include "../../AMMR.version.any"
+
+#define ANYBODY_APPLICATION_LIBRARY_NAME "AMMR" + AMMR_VERSION
+
+
+#path ANYBODY_PATH_BODY "."
+#path ANYBODY_PATH_MANDIBLE "../Mandible/"
+#path ANYBODY_PATH_MODELUTILS "../../Tools/ModelUtilities/"
+#path AMMR_TOOLS "../../Tools/"
+
+#ifpathexists "<ANYBODY_PATH_AMMR>/Documentation"
+   #path AMMR_PATH_DOC "<ANYBODY_PATH_AMMR>/Documentation"
+#else
+   #path AMMR_PATH_DOC "<ANYBODY_PATH_INSTALLDIR>/AMMR/Documentation"
+#endif
+
+#ifndef ANYBODY_PATH_OUTPUT
+  #ifpathexists "<ANYBODY_PATH_MAINFILEDIR>/Output/"
+    #path ANYBODY_PATH_OUTPUT "<ANYBODY_PATH_MAINFILEDIR>/Output/"
+  #else
+    #path ANYBODY_PATH_OUTPUT "<ANYBODY_PATH_MAINFILEDIR>"
+  #endif
+#endif
+
+#ifndef ANYMOCAP_MODEL
+#path ANYMOCAP_PATH "<ANYBODY_PATH_AMMR>/Tools/AnyMoCap"
+#path ANYMOCAP_MODEL "<ANYMOCAP_PATH>/AnyMocapModel.any"
+#endif
+
+//
+// Include misc. class templates and helper macros.
+//
 #include "BodyModels/GenericBodyModel/BodyModel.constants.any"
 #include "BodyModels/GenericBodyModel/Helper.ClassTemplates.any"
 #include "BodyModels/GenericBodyModel/AnyMan.ClassTemplates.any"
@@ -36,4 +82,6 @@ Error("ANYBODY_PATH_TOOLBOX is deprecated. Use ANYBODY_PATH_MODELUTILS instead")
 #undef ANYBODY_BUILTIN_PYTHON_AVAILABLE
 #define ANYBODY_PYTHON_AVAILABLE 1
 #define ANYBODY_BUILTIN_PYTHON_AVAILABLE 1
+#endif
+
 #endif

--- a/libdef.any
+++ b/libdef.any
@@ -1,39 +1,15 @@
-// Configures the model to use this AnyBody Managed Model Repostiory (AMMR
-// Including this file ensures that the model can include the HumanModel
-// and use BM configuration statements etc.
+//// Include this file to configure your model to use this AMMR. 
+//// I.e. put this in top of your model
+// 
+//   #include "<PATH/TO/THIS/FILE/libdef.any"
+// 
+// 
+//// After including this file a model can be created 
+//// by including the HumanModel
+//
+//   #include "<ANYBODY_HUMAN_MODEL>"
+//
 
-#ifndef LIBDEF_ANY
-#define  LIBDEF_ANY
 
-#include "AMMR.version.any"
+#include "Body/AAUHuman/HumanModel.defs.any"
 
-#define ANYBODY_APPLICATION_LIBRARY_NAME "AMMR" + AMMR_VERSION
-
-#path ANYBODY_PATH_AMMR "."
-#path ANYBODY_PATH_BODY "Body/AAUHuman/"
-#path ANYBODY_PATH_MANDIBLE "Body/Mandible/"
-#path ANYBODY_PATH_MODELUTILS "Tools/ModelUtilities/"
-#path AMMR_TOOLS "Tools/"
-
-#ifpathexists "Documentation"
-   #path AMMR_PATH_DOC "Documentation"
-#else
-   #path AMMR_PATH_DOC "<ANYBODY_PATH_INSTALLDIR>/AMMR/Documentation"
-#endif
-
-#ifndef ANYBODY_PATH_OUTPUT
-  #ifpathexists "<ANYBODY_PATH_MAINFILEDIR>/Output/"
-    #path ANYBODY_PATH_OUTPUT "<ANYBODY_PATH_MAINFILEDIR>/Output/"
-  #else
-    #path ANYBODY_PATH_OUTPUT "<ANYBODY_PATH_MAINFILEDIR>"
-  #endif
-#endif
-
-#ifndef ANYMOCAP_MODEL
-#path ANYMOCAP_PATH "Tools/AnyMoCap"
-#path ANYMOCAP_MODEL "<ANYMOCAP_PATH>/AnyMocapModel.any"
-#endif
-
-#include "<ANYBODY_PATH_BODY>/HumanModel.defs.any"
-
-#endif


### PR DESCRIPTION
I have cleanup the top level `libdef.any` in AMMR, so most content is moved to the `Body\AAUHuman\HumanModelDef.any`. 

At the same time I have added an `#include "../../libdef.any"` to the HumanModel file, and added a new `ANYBODY_HUMAN_MODEL` path. 

So besides making the top level `libdef.any` cleaner, it also makes it easier to create 'bare' human model since the file can be included directly: 

```C++
Main = 
{
  #include "D:\AMMRs\ammr\Body\AAUHuman\HumanModel.any"
};
```
or with the more traditional approach with a `libdef.any` file, and the new `ANYBODY_HUMAN_MODEL` flag. 
 
```C++
#include "..\libdef.any"
Main = 
{
  #include "<ANYBODY_HUMAN_MODEL>"
};
```

The old style with `ANYBODY_HUMAN_MODEL` off course still works: 

```
#include "D:\AMMRs\ammr\libdef.any"

Main = 
{
  #include "<ANYBODY_PATH_AMMR>/HumanModel.any"
};
```
 