### PR TITLE
chore: mark pixi.lock as binary and generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,7 @@ Docs export-ignore
 Body\AAUHuman\BodyModels\GenericBodyModel\ammr-beta.any export-ignore
 Body\AAUHuman\BodyModels\GenericBodyModel\git_info.py export-ignore
 CHANGELOG.md export-ignore
-pixi.lock linguist-language=YAML export-ignore
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true export-ignore
 pixi.toml export-ignore
 .editorconfig export-ignore
 


### PR DESCRIPTION
Update .gitattributes to treat pixi.lock as a binary merge file and to
mark it as a generated linguist file. This prevents merge conflicts from
being handled as text and signals to GitHub's language detection that
the file is machine-generated. Also preserves the existing export-ignore
setting.