### PR TITLE
fix: Removed SmallStepAssumptionOnOff set to On in InitialCondition analysis

### DIFF
--- a/Tools/AnyMocap/KinematicStudyForParameterIdentificationSettings.any
+++ b/Tools/AnyMocap/KinematicStudyForParameterIdentificationSettings.any
@@ -1,6 +1,6 @@
 InitialConditions =
 {
-  SmallStepAssumptionOnOff = On;
+  //SmallStepAssumptionOnOff = Off; // Should be Off(default) because initial-conditions solver cannot assume small step from the starting-guess(loadtime) positions
   PosAnalysisOnlyOnOff = On;
   KinematicTol ??=1e-3;
   SolverType = KinSolOverDeterminate;


### PR DESCRIPTION
This is not a good idea and newer AMS may complain about it. 