### PR TITLE
chore: add ammr zip step as pixi command

### DIFF
--- a/Docs/make.bat
+++ b/Docs/make.bat
@@ -44,7 +44,7 @@ git checkout -b archive
 git checkout archive
 git add -f Documentation\*
 git commit -m "doc archive"
-git archive archive -o release.zip
+git archive archive -o ammr-release.zip
 git reset --soft HEAD~
 git reset
 git checkout master

--- a/pixi.toml
+++ b/pixi.toml
@@ -75,4 +75,7 @@ docs = {cmd = "sphinx-build -M html . _build -W --keep-going", cwd = "Docs", des
 docs-linkcheck = {cmd = "sphinx-build -M linkcheck . _build -W --keep-going -a -q ", cwd = "Docs"}
 docs-clean = {cmd = "rm -rf _build", cwd = "Docs"}
 
+[target.win-64.tasks]
+ammr-release-zip = {cmd = "Docs\\make.bat release", description = "Create release.zip via git archive (only tracked files)"}
+
 


### PR DESCRIPTION
Expose the command to bundle the ammr into a release ready zip folder