### PR TITLE
chore: update GH actions windows image for pipelines

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test-windows:
     if: github.repository == 'anybody/ammr'
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-forks.yml
+++ b/.github/workflows/test-forks.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         test_group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       # Triggers a warning at 20 deg
       ShortestPathMaxAngle: 0.3491 
 
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     
     steps:
 


### PR DESCRIPTION
This PR updates the image used for test pipelines running on GH hardware. 
The `windows-2025` is being moved to `windows-2025-vs2026` per 15th of June. 
The new image uses Visual Studio 2026.